### PR TITLE
Rewrite CI so it uploads to registry after the systemtest.

### DIFF
--- a/.github/workflows/ods.yml
+++ b/.github/workflows/ods.yml
@@ -256,8 +256,8 @@ jobs:
 
   # ----------------- Registry Upload --------------------
 
-  registry_upload:
-    name: Upload to Docker Registry
+  adapter_upload:
+    name: Upload Adapter to Docker Registry
     runs-on: ubuntu-latest
 
     needs: [systemtest]
@@ -270,36 +270,11 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: adapter-artifact
-      - name: Download core artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: core-artifact
-      - name: Download scheduler artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: scheduler-artifact
-      - name: Download storage artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: storage-artifact
-      - name: Download liquibase artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: liquibase-artifact
-      - name: Download transformation artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: transformation-artifact
 
-      - name: Load Docker Images from artifacts
+
+      - name: Load Docker Image from artifact
         run: |
-          docker load -i ./core-artifact/core.tar
-          docker load -i ./scheduler-artifact/scheduler.tar
-          docker load -i ./storage-artifact/storage_postgrest.tar
-          docker load -i ./liquibase-artifact/storage_liquibase.tar
-          docker load -i ./transformation-artifact/transformation.tar
           docker load -i ./adapter-artifact/adapter.tar
-          docker load -i ./ui-artifact/ui.tar
 
       - name: Adapter Push to registry
         run: |
@@ -315,6 +290,25 @@ jobs:
           docker push $IMAGE_ID:$ADAPTER_VERSION
           docker push $IMAGE_ID:latest
 
+  core_upload:
+    name: Upload Core to Docker Registry
+    runs-on: ubuntu-latest
+
+    needs: [systemtest]
+
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download core artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: core-artifact
+
+      - name: Load Docker Image from artifact
+        run: |
+          docker load -i ./core-artifact/core.tar
+
       - name: Core Push to registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
@@ -329,6 +323,25 @@ jobs:
           docker push $IMAGE_ID:$CORE_VERSION
           docker push $IMAGE_ID:latest
 
+  scheduler_upload:
+    name: Upload Scheduler to Docker Registry
+    runs-on: ubuntu-latest
+
+    needs: [systemtest]
+
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download scheduler artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: scheduler-artifact
+
+      - name: Load Docker Image from artifact
+        run: |
+          docker load -i ./scheduler-artifact/scheduler.tar
+
       - name: Scheduler Push to registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
@@ -342,6 +355,31 @@ jobs:
 
           docker push $IMAGE_ID:$SCHEDULER_VERSION
           docker push $IMAGE_ID:latest
+
+  storage_upload:
+    name: Upload Storage to Docker Registry
+    runs-on: ubuntu-latest
+
+    needs: [systemtest]
+
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download storage artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: storage-artifact
+      - name: Download liquibase artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: liquibase-artifact
+
+      - name: Load Docker Images from artifacts
+        run: |
+
+          docker load -i ./storage-artifact/storage_postgrest.tar
+          docker load -i ./liquibase-artifact/storage_liquibase.tar
 
       - name: Storage Push to registry
         run: |
@@ -364,6 +402,25 @@ jobs:
           docker push $IMAGE_ID_LIQUIBASE:$STORAGE_VERSION
           docker push $IMAGE_ID_LIQUIBASE:latest
 
+  transformation_upload:
+    name: Upload Transformation to Docker Registry
+    runs-on: ubuntu-latest
+
+    needs: [systemtest]
+
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download transformation artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: transformation-artifact
+
+      - name: Load Docker Image from artifact
+        run: |
+          docker load -i ./transformation-artifact/transformation.tar
+
       - name: Transformation Push to registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
@@ -377,6 +434,25 @@ jobs:
 
           docker push $IMAGE_ID:$TRANSFORMATION_VERSION
           docker push $IMAGE_ID:latest
+
+  ui_upload:
+    name: Upload Adapter to Docker Registry
+    runs-on: ubuntu-latest
+
+    needs: [systemtest]
+
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download ui artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ui-artifact
+
+      - name: Load Docker Image from artifact
+        run: |
+          docker load -i ./ui-artifact/ui.tar
 
       - name: UI Push to registry
         run: |

--- a/.github/workflows/ods.yml
+++ b/.github/workflows/ods.yml
@@ -7,7 +7,7 @@ jobs:
   # ----------------- ADAPTER SERVICE --------------------
 
   adapter-build:
-    name: Adapter Build & Test & Publish
+    name: Adapter Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -40,7 +40,7 @@ jobs:
   # ----------------- CORE SERVICE --------------------
 
   core-build:
-    name: CORE Build & Test & Publish
+    name: CORE Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -73,7 +73,7 @@ jobs:
   # ----------------- SCHEDULER SERVICE --------------------
 
   scheduler-build:
-    name: Scheduler Build & Test & Publish
+    name: Scheduler Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -106,7 +106,7 @@ jobs:
   # ----------------- STORAGE SERVICE --------------------
 
   storage-build:
-    name: Storage Build & Test & Publish
+    name: Storage Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -151,7 +151,7 @@ jobs:
   # ----------------- TRANSFORMATION SERVICE --------------------
 
   transformation-build:
-    name: Transformation Build & Test & Publish
+    name: Transformation Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -184,7 +184,7 @@ jobs:
   # ----------------- UI SERVICE --------------------
 
   ui-build:
-    name: UI Build & Test & Publish
+    name: UI Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -257,7 +257,7 @@ jobs:
   # ----------------- Registry Upload --------------------
 
   adapter_upload:
-    name: Upload Adapter to Docker Registry
+    name: Adapter Publish
     runs-on: ubuntu-latest
 
     needs: [systemtest]
@@ -291,7 +291,7 @@ jobs:
           docker push $IMAGE_ID:latest
 
   core_upload:
-    name: Upload Core to Docker Registry
+    name: Core Publish
     runs-on: ubuntu-latest
 
     needs: [systemtest]
@@ -324,7 +324,7 @@ jobs:
           docker push $IMAGE_ID:latest
 
   scheduler_upload:
-    name: Upload Scheduler to Docker Registry
+    name: Scheduler Publish
     runs-on: ubuntu-latest
 
     needs: [systemtest]
@@ -357,7 +357,7 @@ jobs:
           docker push $IMAGE_ID:latest
 
   storage_upload:
-    name: Upload Storage to Docker Registry
+    name: Storage Publish
     runs-on: ubuntu-latest
 
     needs: [systemtest]
@@ -403,7 +403,7 @@ jobs:
           docker push $IMAGE_ID_LIQUIBASE:latest
 
   transformation_upload:
-    name: Upload Transformation to Docker Registry
+    name: Transformation Publish
     runs-on: ubuntu-latest
 
     needs: [systemtest]
@@ -436,7 +436,7 @@ jobs:
           docker push $IMAGE_ID:latest
 
   ui_upload:
-    name: Upload Adapter to Docker Registry
+    name: UI Publish
     runs-on: ubuntu-latest
 
     needs: [systemtest]

--- a/.github/workflows/ods.yml
+++ b/.github/workflows/ods.yml
@@ -25,21 +25,6 @@ jobs:
           docker-compose logs
           docker-compose -f docker-compose.yml -f docker-compose.ci.yml down
 
-      - name: Push to registry
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/adapter
-
-          ADAPTER_VERSION=$(grep "version =" ./adapter/src/main/resources/application.properties | awk '{print $3}' | sed "s/[']//g")
-
-          docker tag $IMAGE_ID $IMAGE_ID:$ADAPTER_VERSION
-          docker tag $IMAGE_ID $IMAGE_ID:latest
-
-          docker push $IMAGE_ID:$ADAPTER_VERSION
-          docker push $IMAGE_ID:latest
-
       - name: Save Docker image as artifact
         run: |
           IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/adapter
@@ -73,21 +58,6 @@ jobs:
           docker-compose logs
           docker-compose -f docker-compose.yml -f docker-compose.ci.yml down
 
-      - name: Push to registry
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-          CORE_VERSION=$(grep "version =" ./core/src/main/resources/application.properties | awk '{print $3}' | sed "s/[']//g")
-
-          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/core
-
-          docker tag $IMAGE_ID $IMAGE_ID:$CORE_VERSION
-          docker tag $IMAGE_ID $IMAGE_ID:latest
-
-          docker push $IMAGE_ID:$CORE_VERSION
-          docker push $IMAGE_ID:latest
-
       - name: Save Docker image as artifact
         run: |
           IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/core
@@ -120,21 +90,6 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --exit-code-from scheduler-it scheduler-it
           docker-compose logs
           docker-compose -f docker-compose.yml -f docker-compose.ci.yml down
-
-      - name: Push to registry
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/scheduler
-
-          SCHEDULER_VERSION=$(grep "version" scheduler/package.json | awk '{print $2}' | sed 's/[,"]//g')
-
-          docker tag $IMAGE_ID $IMAGE_ID:$SCHEDULER_VERSION
-          docker tag $IMAGE_ID $IMAGE_ID:latest
-
-          docker push $IMAGE_ID:$SCHEDULER_VERSION
-          docker push $IMAGE_ID:latest
 
       - name: Save Docker image as artifact
         run: |
@@ -171,28 +126,6 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --exit-code-from storage-it storage-it
           docker-compose logs
           docker-compose -f docker-compose.yml -f docker-compose.ci.yml down
-
-      - name: Push to registry
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-          STORAGE_VERSION=$(grep "VERSION" ./storage/version.txt | awk '{print $3}' | sed 's/[,"]//g')
-
-          IMAGE_ID_STORAGE=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/storage
-          IMAGE_ID_LIQUIBASE=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/storage-db-liquibase
-
-          docker tag $IMAGE_ID_STORAGE $IMAGE_ID_STORAGE:$STORAGE_VERSION
-          docker tag $IMAGE_ID_STORAGE $IMAGE_ID_STORAGE:latest
-
-          docker tag $IMAGE_ID_LIQUIBASE $IMAGE_ID_LIQUIBASE:$STORAGE_VERSION
-          docker tag $IMAGE_ID_LIQUIBASE $IMAGE_ID_LIQUIBASE:latest
-
-          docker push $IMAGE_ID_STORAGE:$STORAGE_VERSION
-          docker push $IMAGE_ID_STORAGE:latest
-
-          docker push $IMAGE_ID_LIQUIBASE:$STORAGE_VERSION
-          docker push $IMAGE_ID_LIQUIBASE:latest
 
       - name: Save Docker image as artifact
         run: |
@@ -236,21 +169,6 @@ jobs:
           docker-compose logs
           docker-compose -f docker-compose.yml -f docker-compose.ci.yml down
 
-      - name: Push to registry
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/transformation
-
-          TRANSFORMATION_VERSION=$(grep "version" ./transformation/package.json | awk '{print $2}' | sed 's/[,"]//g')
-
-          docker tag $IMAGE_ID $IMAGE_ID:$TRANSFORMATION_VERSION
-          docker tag $IMAGE_ID $IMAGE_ID:latest
-
-          docker push $IMAGE_ID:$TRANSFORMATION_VERSION
-          docker push $IMAGE_ID:latest
-
       - name: Save Docker image as artifact
         run: |
           IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/transformation
@@ -276,21 +194,16 @@ jobs:
         run: |
           docker-compose -f docker-compose.yml build ui
 
-      - name: Push to registry
-        if: github.ref == 'refs/heads/master'
+      - name: Save Docker image as artifact
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
           IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/ui
+          docker save $IMAGE_ID > ui.tar
 
-          UI_VERSION=$(grep "version" ./ui/package.json | awk '{print $2}' | sed 's/[,"]//g')
-
-          docker tag $IMAGE_ID $IMAGE_ID:$UI_VERSION
-          docker tag $IMAGE_ID $IMAGE_ID:latest
-
-          docker push $IMAGE_ID:$UI_VERSION
-          docker push $IMAGE_ID:latest
-
+      - name: Upload Docker image as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ui-artifact
+          path: ui.tar
 
   # ----------------- SYSTEMTEST --------------------
 
@@ -340,3 +253,141 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.st.yml up --exit-code-from system-test system-test
           docker-compose logs
           docker-compose -f docker-compose.yml -f docker-compose.st.yml down
+
+  # ----------------- Registry Upload --------------------
+
+  registry_upload:
+    name: Upload to Docker Registry
+    runs-on: ubuntu-latest
+
+    needs: [systemtest]
+
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download adapter artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: adapter-artifact
+      - name: Download core artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: core-artifact
+      - name: Download scheduler artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: scheduler-artifact
+      - name: Download storage artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: storage-artifact
+      - name: Download liquibase artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: liquibase-artifact
+      - name: Download transformation artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: transformation-artifact
+
+      - name: Load Docker Images from artifacts
+        run: |
+          docker load -i ./core-artifact/core.tar
+          docker load -i ./scheduler-artifact/scheduler.tar
+          docker load -i ./storage-artifact/storage_postgrest.tar
+          docker load -i ./liquibase-artifact/storage_liquibase.tar
+          docker load -i ./transformation-artifact/transformation.tar
+          docker load -i ./adapter-artifact/adapter.tar
+          docker load -i ./ui-artifact/ui.tar
+
+      - name: Adapter Push to registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/adapter
+
+          ADAPTER_VERSION=$(grep "version =" ./adapter/src/main/resources/application.properties | awk '{print $3}' | sed "s/[']//g")
+
+          docker tag $IMAGE_ID $IMAGE_ID:$ADAPTER_VERSION
+          docker tag $IMAGE_ID $IMAGE_ID:latest
+
+          docker push $IMAGE_ID:$ADAPTER_VERSION
+          docker push $IMAGE_ID:latest
+
+      - name: Core Push to registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+          CORE_VERSION=$(grep "version =" ./core/src/main/resources/application.properties | awk '{print $3}' | sed "s/[']//g")
+
+          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/core
+
+          docker tag $IMAGE_ID $IMAGE_ID:$CORE_VERSION
+          docker tag $IMAGE_ID $IMAGE_ID:latest
+
+          docker push $IMAGE_ID:$CORE_VERSION
+          docker push $IMAGE_ID:latest
+
+      - name: Scheduler Push to registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/scheduler
+
+          SCHEDULER_VERSION=$(grep "version" scheduler/package.json | awk '{print $2}' | sed 's/[,"]//g')
+
+          docker tag $IMAGE_ID $IMAGE_ID:$SCHEDULER_VERSION
+          docker tag $IMAGE_ID $IMAGE_ID:latest
+
+          docker push $IMAGE_ID:$SCHEDULER_VERSION
+          docker push $IMAGE_ID:latest
+
+      - name: Storage Push to registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+          STORAGE_VERSION=$(grep "VERSION" ./storage/version.txt | awk '{print $3}' | sed 's/[,"]//g')
+
+          IMAGE_ID_STORAGE=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/storage
+          IMAGE_ID_LIQUIBASE=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/storage-db-liquibase
+
+          docker tag $IMAGE_ID_STORAGE $IMAGE_ID_STORAGE:$STORAGE_VERSION
+          docker tag $IMAGE_ID_STORAGE $IMAGE_ID_STORAGE:latest
+
+          docker tag $IMAGE_ID_LIQUIBASE $IMAGE_ID_LIQUIBASE:$STORAGE_VERSION
+          docker tag $IMAGE_ID_LIQUIBASE $IMAGE_ID_LIQUIBASE:latest
+
+          docker push $IMAGE_ID_STORAGE:$STORAGE_VERSION
+          docker push $IMAGE_ID_STORAGE:latest
+
+          docker push $IMAGE_ID_LIQUIBASE:$STORAGE_VERSION
+          docker push $IMAGE_ID_LIQUIBASE:latest
+
+      - name: Transformation Push to registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/transformation
+
+          TRANSFORMATION_VERSION=$(grep "version" ./transformation/package.json | awk '{print $2}' | sed 's/[,"]//g')
+
+          docker tag $IMAGE_ID $IMAGE_ID:$TRANSFORMATION_VERSION
+          docker tag $IMAGE_ID $IMAGE_ID:latest
+
+          docker push $IMAGE_ID:$TRANSFORMATION_VERSION
+          docker push $IMAGE_ID:latest
+
+      - name: UI Push to registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+          IMAGE_ID=$(sed -n 's/^DOCKER_REGISTRY=//p' .env)/ui
+
+          UI_VERSION=$(grep "version" ./ui/package.json | awk '{print $2}' | sed 's/[,"]//g')
+
+          docker tag $IMAGE_ID $IMAGE_ID:$UI_VERSION
+          docker tag $IMAGE_ID $IMAGE_ID:latest
+
+          docker push $IMAGE_ID:$UI_VERSION
+          docker push $IMAGE_ID:latest


### PR DESCRIPTION
Each service is built and tested and afterwards its image is saved and uploaded as an artifact.

The systemtest downloads the artifacts accordingly and runs only if all the required prior jobs were successful.

After a successful systemtest run and only if on master each image is downloaded and loaded from the corresponding artifact, then it gets uploaded to the registry. This happens in parallel to speed up average workflow time. 