### PR TITLE
Access 2nd-level routing in vue-app directly.

### DIFF
--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -2,7 +2,7 @@
 const MonacoEditorPlugin = require('monaco-editor-webpack-plugin')
 
 module.exports = {
-  publicPath: './',
+  publicPath: '/',
   configureWebpack: {
     devServer: {
       open: true,


### PR DESCRIPTION
closes issue #58 

Accessing a path 2 levels deep into the routing (e.g. `/datasources/new`) resulted in an error.

I think the underlying issue has to do with loading the JS-files that are needed to execute the vue-app.

After some googling I encountered https://stackoverflow.com/questions/49276879/second-level-vue-route-throws-error-when-accessed-directly and https://webpack.js.org/guides/public-path/

Changing the vue.config.js fixed the problem (check the "Changes"-tab ;) )