### PR TITLE
doc: Change picture embedding in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please make sure that commits related to an issue (e.g. closing an issue) contai
 
 We use the microservice architectural style in this project. The microservices are located in the sub-directories and communicate at runtime over network with each other. Each Microservice has its own defined interface that has to be used by other services, direct access to the database of other microservices is strictly prohibited. In production, each microservice can be multiplied in order to scale the system (except the scheduler at the moment).
 
-![Microservice Architecture](./doc/service_arch.png)
+![Microservice Architecture](https://github.com/jvalue/open-data-service/blob/master/doc/service_arch.png)
 
 | Microservice | Description |
 |----|----|
@@ -60,26 +60,25 @@ To demonstrate the ODS we will create a new pipeline to fetch water level data f
 First, go to the Pipelines page and click on `Create new Pipeline`.
 The configuration workflow for creating a new pipeline is divided into the following five steps.
 
-![alt](doc/configuration-example/01_overview.jpg)
-
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/01_overview.jpg)
 
 Step 1: Name the pipeline.
 
-![alt](doc/configuration-example/02_pipeline_name.jpg)
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/02_pipeline_name.jpg)
 
 Step 2: Configure an adapter to crawl the data. You can use the prefilled example settings.
 
-![alt](doc/configuration-example/03_adapter_config.jpg)
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/03_adapter_config.jpg)
 
 Step 3: In this step, you can manipulate the raw data to fit your needs by writing JavaScript code.
 The `data` object represents the incoming raw data.
 In this example, the attribute `test` is added to the `data` object before returning it.
 
-![alt](doc/configuration-example/04_transformation.jpg)
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/04_transformation.jpg)
 
 Step 4: Describe additional meta-data.
 
-![alt](doc/configuration-example/05_meta-data.jpg)
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/05_meta-data.jpg)
 
 Step 5: Configure the interval of how often the data should be fetched.
 If `Periodic execution` is disabled the data will be fetched only once.
@@ -87,15 +86,15 @@ With the two sliders, you can choose the interval duration.
 The first execution of the pipeline will be after the `Time of First Execution` plus the interval time.
 Please choose 1 minute, so that you don't have to wait too long for the first data to arrive.
 
-![alt](doc/configuration-example/06_trigger.jpg)
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/06_trigger.jpg)
 
 The configuration of the pipeline is now finished. In the overview, you see now the recently created pipeline.
 
-![alt](doc/configuration-example/07_overview_with_data.jpg)
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/07_overview_with_data.jpg)
 
 By clicking on the `Data` button inside the table you see the collected data by the pipeline.
 
-![alt](doc/configuration-example/08_storage.jpg)
+![alt](https://github.com/jvalue/open-data-service/blob/master/doc/configuration-example/08_storage.jpg)
 
 In this storage view, you see all data sets for the related pipeline. On top of this list, a static link shows the URL to fetch the data with a REST client.
 Each data entry in the list can be expanded to see the fetched data and additional meta-data.


### PR DESCRIPTION
The picture path in the README file was relative
(doc/configuration-example/01_overview.jpg.), now the path of the
images is absolute
(https://github.com/jvalue/open-data-service/blob/master/doc/
configuration-example/01_overview.jpg).

This commit replaces all the relative paths for absolute paths.

Fixes: #62