### PR TITLE
Show only master build state as badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Open Data Service (ODS)](https://github.com/jvalue/open-data-service/workflows/Open%20Data%20Service%20(ODS)/badge.svg)
+![Open Data Service (ODS)](https://github.com/jvalue/open-data-service/workflows/Open%20Data%20Service%20(ODS)/badge.svg?branch=master)
 
 # Open Data Service (ODS)
 


### PR DESCRIPTION
At the moment the status badge will show very often that the build fail because it failed in one of the dev branches, even the CI in the master branch runs successfully.

With this PR it will only show the state of the master branch.
