### PR TITLE
Datasource trigger integration test

### DIFF
--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -2,6 +2,9 @@ const request = require('supertest')
 const waitOn = require('wait-on')
 
 const URL = process.env.ADAPTER_API || 'http://localhost:9000/api/adapter'
+const MOCK_SERVER_PORT = process.env.MOCK_SERVER_PORT || 8081
+const MOCK_SERVER_HOST = process.env.MOCK_SERVER_HOST || 'localhost'
+const MOCK_SERVER_URL = 'http://' + MOCK_SERVER_HOST + ':' + MOCK_SERVER_PORT
 
 describe('Adapter Configuration', () => {
   console.log('Adapter-Service URL= ' + URL)
@@ -184,6 +187,33 @@ describe('Adapter Configuration', () => {
   })
 })
 
+test('POST datasources/{id}/trigger', async () => {
+  const datasourceResponse = await request(URL)
+    .post('/datasources')
+    .send(dynamicDatasourceConfig)
+  const datasourceId = datasourceResponse.body.id
+
+  const dataMetaData = await request(URL)
+    .post('/datasources/' + datasourceId + '/trigger')
+    .send(runtimeParameters)
+
+  const id = dataMetaData.body.id
+  const data = await request(URL)
+    .get('/data/' + id)
+    .send()
+
+  const delResponse = await request(URL)
+    .delete('/datasources/')
+    .send()
+
+  expect(delResponse.status).toEqual(204)
+  expect(dataMetaData.status).toEqual(200)
+  expect(dataMetaData.body.id).toBeGreaterThanOrEqual(0)
+  expect(dataMetaData.body.location).toEqual('/data/' + id)
+  expect(data.status).toEqual(200)
+  expect(data.body.id).toBe(runtimeParameters.parameters.id)
+})
+
 const datasourceConfig = {
   id: 12345,
   protocol: {
@@ -206,5 +236,37 @@ const datasourceConfig = {
     license: 'none',
     displayName: 'test datasource 1',
     description: 'integraiton testing datasources'
+  }
+}
+
+const dynamicDatasourceConfig = {
+  id: 54321,
+  protocol: {
+    type: 'HTTP',
+    parameters: {
+      location: MOCK_SERVER_URL + '/json/{id}',
+      encoding: 'UTF-8'
+    }
+  },
+  format: {
+    type: 'JSON',
+    parameters: {}
+  },
+  trigger: {
+    firstExecution: '1905-12-01T02:30:00.123Z',
+    periodic: false,
+    interval: 50000
+  },
+  metadata: {
+    author: 'icke',
+    license: 'none',
+    displayName: 'test datasource 2',
+    description: 'integration testing dynamic datasources'
+  }
+}
+
+const runtimeParameters = {
+  parameters: {
+    id: '2'
   }
 }

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -194,12 +194,12 @@ test('POST datasources/{id}/trigger', async () => {
   const dynDatasourceId = dynamicDatasourceResponse.body.id
 
   const dynamicDataMetaData = await request(URL)
-    .post('/datasources/' + dynDatasourceId + '/trigger')
+    .post(`/datasources/${dynDatasourceId}/trigger`)
     .send(runtimeParameters)
 
   const dynId = dynamicDataMetaData.body.id
   const dynData = await request(URL)
-    .get('/data/' + dynId)
+    .get(`/data/${dynId}`)
     .send()
 
   const normalDatasourceResponse = await request(URL)
@@ -208,12 +208,12 @@ test('POST datasources/{id}/trigger', async () => {
   const normalDatasourceId = normalDatasourceResponse.body.id
 
   const normalDataMetaData = await request(URL)
-    .post('/datasources/' + normalDatasourceId + '/trigger')
+    .post(`/datasources/${normalDatasourceId}/trigger`)
     .send(null)
 
   const normalId = normalDataMetaData.body.id
   const normalData = await request(URL)
-    .get('/data/' + normalId)
+    .get(`/data/${normalId}`)
     .send()
 
   const delResponse = await request(URL)
@@ -223,12 +223,12 @@ test('POST datasources/{id}/trigger', async () => {
   expect(delResponse.status).toEqual(204)
   expect(dynamicDataMetaData.status).toEqual(200)
   expect(dynamicDataMetaData.body.id).toBeGreaterThanOrEqual(0)
-  expect(dynamicDataMetaData.body.location).toEqual('/data/' + dynId)
+  expect(dynamicDataMetaData.body.location).toEqual(`/data/${dynId}`)
   expect(dynData.status).toEqual(200)
   expect(dynData.body.id).toBe(runtimeParameters.parameters.id)
   expect(normalDataMetaData.status).toEqual(200)
   expect(normalDataMetaData.body.id).toBeGreaterThanOrEqual(0)
-  expect(normalDataMetaData.body.location).toEqual('/data/' + normalId)
+  expect(normalDataMetaData.body.location).toEqual(`/data/${normalId}`)
   expect(normalData.status).toEqual(200)
   expect(normalData.body.id).toBe('1')
 })

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -5,6 +5,7 @@ const URL = process.env.ADAPTER_API || 'http://localhost:9000/api/adapter'
 const MOCK_SERVER_PORT = process.env.MOCK_SERVER_PORT || 8081
 const MOCK_SERVER_HOST = process.env.MOCK_SERVER_HOST || 'localhost'
 const MOCK_SERVER_URL = 'http://' + MOCK_SERVER_HOST + ':' + MOCK_SERVER_PORT
+const RABBIT_URL = `http://${process.env.RABBIT_HOST}:15672`
 
 describe('Adapter Configuration', () => {
   console.log('Adapter-Service URL= ' + URL)
@@ -13,8 +14,12 @@ describe('Adapter Configuration', () => {
     try {
       const pingUrl = URL + '/version'
       console.log('Waiting for service with URL: ' + pingUrl)
-      await waitOn({ resources: [pingUrl], timeout: 50000 })
+      console.log('Waiting for service with URL: ' + MOCK_SERVER_URL)
+      console.log('Waiting for service with URL: ' + RABBIT_URL)
+      await waitOn({ resources: [pingUrl, MOCK_SERVER_URL, RABBIT_URL], timeout: 50000 })
       console.log('[online] Service with URL:  ' + pingUrl)
+      console.log('[online] Service with URL:  ' + MOCK_SERVER_URL)
+      console.log('[online] Service with URL:  ' + RABBIT_URL)
     } catch (err) {
       process.exit(1)
     }

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -192,33 +192,19 @@ describe('Adapter Configuration', () => {
   })
 })
 
-test('POST datasources/{id}/trigger', async () => {
-  const dynamicDatasourceResponse = await request(URL)
+test('POST datasources/{id}/trigger dynamic', async () => {
+  const datasourceResponse = await request(URL)
     .post('/datasources')
     .send(dynamicDatasourceConfig)
-  const dynDatasourceId = dynamicDatasourceResponse.body.id
+  const datasourceId = datasourceResponse.body.id
 
-  const dynamicDataMetaData = await request(URL)
-    .post(`/datasources/${dynDatasourceId}/trigger`)
+  const dataMetaData = await request(URL)
+    .post(`/datasources/${datasourceId}/trigger`)
     .send(runtimeParameters)
 
-  const dynId = dynamicDataMetaData.body.id
-  const dynData = await request(URL)
-    .get(`/data/${dynId}`)
-    .send()
-
-  const normalDatasourceResponse = await request(URL)
-    .post('/datasources')
-    .send(notDynamicDatasourceConfig)
-  const normalDatasourceId = normalDatasourceResponse.body.id
-
-  const normalDataMetaData = await request(URL)
-    .post(`/datasources/${normalDatasourceId}/trigger`)
-    .send(null)
-
-  const normalId = normalDataMetaData.body.id
-  const normalData = await request(URL)
-    .get(`/data/${normalId}`)
+  const id = dataMetaData.body.id
+  const data = await request(URL)
+    .get(`/data/${id}`)
     .send()
 
   const delResponse = await request(URL)
@@ -226,14 +212,37 @@ test('POST datasources/{id}/trigger', async () => {
     .send()
 
   expect(delResponse.status).toEqual(204)
-  expect(dynamicDataMetaData.status).toEqual(200)
-  expect(dynamicDataMetaData.body.id).toBeGreaterThanOrEqual(0)
-  expect(dynamicDataMetaData.body.location).toEqual(`/data/${dynId}`)
-  expect(dynData.status).toEqual(200)
-  expect(dynData.body.id).toBe(runtimeParameters.parameters.id)
-  expect(normalDataMetaData.status).toEqual(200)
-  expect(normalDataMetaData.body.id).toBeGreaterThanOrEqual(0)
-  expect(normalDataMetaData.body.location).toEqual(`/data/${normalId}`)
+  expect(datasourceResponse.status).toEqual(201)
+  expect(dataMetaData.status).toEqual(200)
+  expect(dataMetaData.body.id).toBeGreaterThanOrEqual(0)
+  expect(dataMetaData.body.location).toEqual(`/data/${id}`)
+  expect(data.status).toEqual(200)
+  expect(data.body.id).toBe(runtimeParameters.parameters.id)
+})
+
+test('POST datasources/{id}/trigger static', async () => {
+  const datasourceResponse = await request(URL)
+    .post('/datasources')
+    .send(staticDatasourceConfig)
+  const datasourceId = datasourceResponse.body.id
+
+  const dataMetaData = await request(URL)
+    .post(`/datasources/${datasourceId}/trigger`)
+    .send(null)
+
+  const id = dataMetaData.body.id
+  const normalData = await request(URL)
+    .get(`/data/${id}`)
+    .send()
+
+  const delResponse = await request(URL)
+    .delete('/datasources/')
+    .send()
+
+  expect(delResponse.status).toEqual(204)
+  expect(dataMetaData.status).toEqual(200)
+  expect(dataMetaData.body.id).toBeGreaterThanOrEqual(0)
+  expect(dataMetaData.body.location).toEqual(`/data/${id}`)
   expect(normalData.status).toEqual(200)
   expect(normalData.body.id).toBe('1')
 })
@@ -289,7 +298,7 @@ const dynamicDatasourceConfig = {
   }
 }
 
-const notDynamicDatasourceConfig = {
+const staticDatasourceConfig = {
   id: -1,
   protocol: {
     type: 'HTTP',

--- a/adapter/integration-test/src/mock.server.js
+++ b/adapter/integration-test/src/mock.server.js
@@ -14,6 +14,11 @@ router.get('/json', async ctx => {
   ctx.body = { whateverwillbe: 'willbe', quesera: 'sera' }
 })
 
+router.get('/json/:id', async ctx => {
+  console.log('Get /json/' + ctx.params.id)
+  ctx.body = { id: ctx.params.id }
+})
+
 router.get('/xml', async ctx => {
   console.log('GET /xml')
 


### PR DESCRIPTION
The integration test for the datasource trigger endpoint. There is a new endpoint for the mock server that dynamically responds to a URI. The test is done once with free variables and once without free variables with an empty POST request.
@georg-schwarz @mathiaszinnen 