### PR TITLE
Fix documentation to include dependencies for system-test

### DIFF
--- a/system-test/README.md
+++ b/system-test/README.md
@@ -10,10 +10,10 @@ There are three ways of executing the system test:
 ### 2) Testing locally in the docker environment
 * Build the latest version of the open-data-service via ```docker-compose build``` in the project root directory.
 * Start the open-data-service via ```docker-compose up -d``` in the projects root directory (Startup can be speeded up by appending ```--scale ui=0```). 
-* Run the system-test by ```docker-compose -f docker-compose.st.yml up```. If you want your changes to be applied, you have to rebuild first. 
+* Run the system-test by ```docker-compose -f docker-compose.yml -f docker-compose.st.yml up system-test```. If you want your changes to be applied, you have to rebuild first. 
   
 ### 3) Testing locally outside of the docker environment
 * Build and start the ods as outlined above.
-* Start the mock-server by ```docker-compose -f docker-compose.st.yml up mock-server```.
+* Start the mock-server by ```docker-compose -f docker-compose.yml -f docker-compose.st.yml up mock-server```.
 * Install necessary dependencies by executing ```npm i``` in the system-test directory.
 * Run the system test with your favourite IDE or by executing ```npm run test``` in the system-test directory.


### PR DESCRIPTION
A system-test is depended on rabbitmq, wich is defined in the docker-compose.yml. 
The docker-compose up commands need to include the base docker-compose file. 
The pull request addresses issue #115 