### PR TITLE
Fix rabbitmq url for system-test

### DIFF
--- a/docker-compose.st.yml
+++ b/docker-compose.st.yml
@@ -24,6 +24,7 @@ services:
       MOCK_SERVER_API: http://mock-server:8080
       NOTIFICATION_API: http://notification:8080
       RABBIT_HOST: rabbitmq
+      RABBIT_API: http://rabbitmq:15672
 
   mock-server:
     build:

--- a/system-test/src/system.test.js
+++ b/system-test/src/system.test.js
@@ -7,7 +7,7 @@ const SCHEDULER_URL = process.env.SCHEDULER_API || 'http://localhost:9000/api/sc
 const ADAPTER_URL = process.env.ADAPTER_API || 'http://localhost:9000/api/adapter'
 const TRANSFORMATION_URL = process.env.TRANSFORMATION_API || 'http://localhost:9000/api/transformation'
 const MOCK_SERVER_URL = process.env.MOCK_SERVER_API || 'http://localhost:9000/api/system-tests/mock-server'
-const RABBIT_URL = `http://${process.env.RABBIT_HOST}:15672`
+const RABBIT_URL = process.env.RABBIT_API || 'http://localhost:9000/api/rabbitmq'
 
 const STORAGE_DOCKER = process.env.STORAGE_API || 'http://storage:3000' // needed to run tests outside of docker environment
 const MOCK_SERVER_DOCKER = process.env.MOCK_SERVER_API || 'http://mock-server:8080'


### PR DESCRIPTION
At the moment it is not possible to run the system-test locally via `npm run test` without errors. This is because the URL for rabbitmq is undefined if the system-test is not started through Docker. This commit ensures that the locally running rabbitmq service is used in this case.