### PR TITLE
Required parameters for importer

### DIFF
--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporter.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporter.java
@@ -54,10 +54,6 @@ public class HttpImporter extends Importer {
   }
 
   @Override
-  protected List<ImporterParameterDescription> getRequiredParameters() {
-    return getAvailableParameters().stream().filter(x -> !x.getName().equals("defaultParameters")).collect(Collectors.toList());
-  }
-  @Override
   protected String doFetch(Map<String, Object> parameters) {
     validateParameters(parameters);
     String location = parameters.get("location").toString();

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporter.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporter.java
@@ -16,7 +16,7 @@ public class HttpImporter extends Importer {
   private final List<ImporterParameterDescription> parameters =  Collections.unmodifiableList(List.of(
       new ImporterParameterDescription("location", "String of the URI for the HTTP call", String.class),
       new ImporterParameterDescription("encoding", "Encoding of the source. Available encodings: ISO-8859-1, US-ASCII, UTF-8", String.class),
-      new ImporterParameterDescription("defaultParameters", "Default values for open parameters in the URI", RuntimeParameters.class)
+      new ImporterParameterDescription("defaultParameters", "Default values for open parameters in the URI", false, RuntimeParameters.class)
     ));
   private final RestTemplate restTemplate;
 

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/Importer.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/Importer.java
@@ -2,6 +2,7 @@ package org.jvalue.ods.adapterservice.adapter.importer;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -27,6 +28,16 @@ public abstract class Importer {
     protected void validateParameters(Map<String, Object> inputParameters) {
       boolean illegalArguments = false;
       String illegalArgumentsMessage = "";
+
+      var unnecessaryArguments = inputParameters.keySet().stream()
+        .filter(o -> !getAvailableParameters().contains(o)).collect(Collectors.toList());
+      if (unnecessaryArguments.size() > 0) {
+        illegalArguments = true;
+        for (var argument :
+          unnecessaryArguments) {
+          illegalArgumentsMessage +=  argument + " is not needed by importer \n";
+        }
+      }
 
       for (ImporterParameterDescription requiredParameter : getRequiredParameters()) {
         if (inputParameters.get(requiredParameter.getName()) == null) {

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/Importer.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/Importer.java
@@ -29,8 +29,11 @@ public abstract class Importer {
       boolean illegalArguments = false;
       String illegalArgumentsMessage = "";
 
+
+      List<String> possibleParameters = getAvailableParameters().stream()
+        .map(ImporterParameterDescription::getName).collect(Collectors.toList());
       var unnecessaryArguments = inputParameters.keySet().stream()
-        .filter(o -> !getAvailableParameters().contains(o)).collect(Collectors.toList());
+        .filter(o -> !possibleParameters.contains(o)).collect(Collectors.toList());
       if (unnecessaryArguments.size() > 0) {
         illegalArguments = true;
         for (var argument :

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/Importer.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/Importer.java
@@ -14,7 +14,8 @@ public abstract class Importer {
     public abstract List<ImporterParameterDescription> getAvailableParameters();
 
     protected List<ImporterParameterDescription> getRequiredParameters() {
-      return getAvailableParameters();
+      return getAvailableParameters().stream()
+        .filter(ImporterParameterDescription::isRequired).collect(Collectors.toList());
     }
 
     public final String fetch(Map<String, Object> parameters) {

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/ImporterParameterDescription.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/importer/ImporterParameterDescription.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 public class ImporterParameterDescription {
     private String name;
     private String description;
+    private boolean required;
     private Class type;
 
     private ImporterParameterDescription() {    }
@@ -12,10 +13,18 @@ public class ImporterParameterDescription {
     public ImporterParameterDescription(String name, String description, Class type) {
         this.name = name;
         this.description = description;
+        this.required = true;
         this.type = type;
     }
 
-    public String getName() {
+  public ImporterParameterDescription(String name, String description, boolean required, Class type) {
+    this.name = name;
+    this.description = description;
+    this.required = required;
+    this.type = type;
+  }
+
+  public String getName() {
         return name;
     }
 
@@ -39,18 +48,27 @@ public class ImporterParameterDescription {
         this.type = type;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ImporterParameterDescription that = (ImporterParameterDescription) o;
-        return Objects.equals(name, that.name) &&
-                Objects.equals(description, that.description) &&
-                Objects.equals(type, that.type);
-    }
+  public boolean isRequired() {
+    return required;
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, description, type);
-    }
+  public void setRequired(boolean required) {
+    this.required = required;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ImporterParameterDescription)) return false;
+    ImporterParameterDescription that = (ImporterParameterDescription) o;
+    return isRequired() == that.isRequired() &&
+      Objects.equals(getName(), that.getName()) &&
+      Objects.equals(getDescription(), that.getDescription()) &&
+      Objects.equals(getType(), that.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getDescription(), isRequired(), getType());
+  }
 }

--- a/adapter/src/test/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporterTest.java
+++ b/adapter/src/test/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporterTest.java
@@ -49,6 +49,11 @@ public class HttpImporterTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testTypoInArguments() throws IllegalArgumentException {
+        String result = importer.fetch(Map.of("locationS", from.getPath(), "encodingS", "UTF-8"));
+    }
+
+  @Test(expected = IllegalArgumentException.class)
     public void testFetchMissingURI() throws IOException {
         importer.fetch(Map.of());
     }

--- a/adapter/src/test/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporterTest.java
+++ b/adapter/src/test/java/org/jvalue/ods/adapterservice/adapter/importer/HttpImporterTest.java
@@ -56,9 +56,9 @@ public class HttpImporterTest {
     @Test
     public void testSerialization() throws IOException {
         JsonNode expected = mapper.readTree("{\"parameters\":[" +
-            "{\"name\":\"location\", \"description\":\"String of the URI for the HTTP call\", \"type\":\"java.lang.String\"}," +
-            "{\"name\":\"encoding\", \"description\":\"Encoding of the source. Available encodings: ISO-8859-1, US-ASCII, UTF-8\", \"type\":\"java.lang.String\"}," +
-            "{\"name\":\"defaultParameters\", \"description\":\"Default values for open parameters in the URI\", \"type\":\"org.jvalue.ods.adapterservice.datasource.model.RuntimeParameters\"}" +
+            "{\"name\":\"location\", \"description\":\"String of the URI for the HTTP call\", \"type\":\"java.lang.String\", \"required\": true}," +
+            "{\"name\":\"encoding\", \"description\":\"Encoding of the source. Available encodings: ISO-8859-1, US-ASCII, UTF-8\", \"type\":\"java.lang.String\", \"required\": true}," +
+            "{\"name\":\"defaultParameters\", \"description\":\"Default values for open parameters in the URI\", \"type\":\"org.jvalue.ods.adapterservice.datasource.model.RuntimeParameters\", \"required\": false}" +
           "], \"type\":\"HTTP\",\"description\":\"Plain HTTP\"}");
         JsonNode result = mapper.valueToTree(importer);
 


### PR DESCRIPTION
I changed the validation. Now you can define with a constructor if an import parameter is needed or not. Default behavior is required. Additionally I changed that you cannot use import parameters which are not defined for the specific importer.