### PR TITLE
Update typescript target to es2018

### DIFF
--- a/notification/.eslintrc
+++ b/notification/.eslintrc
@@ -1,0 +1,25 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "extends": ["standard", "plugin:@typescript-eslint/recommended"],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/indent": [2, 2],
+    "@typescript-eslint/no-use-before-define": ["warn", { "functions": false, "classes": true }],
+    "max-len": [2, 120, 4, { "ignoreUrls": true }],
+    "@typescript-eslint/explicit-function-return-type": [1, { "allowExpressions": true }],
+    "@typescript-eslint/no-floating-promises": "warn"
+  }
+}

--- a/notification/tsconfig.json
+++ b/notification/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "strict": true,
     "jsx": "preserve",
@@ -15,7 +15,7 @@
     "paths": {
       "@/*": ["src/*", "tests/*"]
     },
-    "lib": ["es5"  , "es6", "dom"],
+    "lib": ["es2018"],
     "outDir": "dist"
   },
   "include": [

--- a/scheduler/tsconfig.json
+++ b/scheduler/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "strict": true,
     "jsx": "preserve",
@@ -13,7 +13,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "lib": ["es5"],
+    "lib": ["es2018"],
     "outDir": "dist"
   },
   "include": [

--- a/storage/storage-mq/src/storage-content/postgresStorageContentRepository.ts
+++ b/storage/storage-mq/src/storage-content/postgresStorageContentRepository.ts
@@ -170,10 +170,10 @@ export class PostgresStorageContentRepository implements StorageContentRepositor
         try {
             client = await this.connectionPool.connect()
             const { rows } = await client.query(insertStatement, values)
-            console.debug("Content sucessfully persisted.")
+            console.debug("Content successfully persisted.")
             return Promise.resolve(rows[0]["id"] as number)
         } catch (err) {
-            const errMsg = `Could save content data: ${err}`
+            const errMsg = `Could not save content data: ${err}`
             console.error(errMsg)
             return Promise.reject(err)
         } finally {

--- a/storage/storage-mq/tsconfig.json
+++ b/storage/storage-mq/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "strict": true,
     "jsx": "preserve",
@@ -13,7 +13,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "lib": ["es5"],
+    "lib": ["es2018"],
     "outDir": "dist"
   },
   "include": [

--- a/transformation/tsconfig.json
+++ b/transformation/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "strict": true,
     "jsx": "preserve",
@@ -13,7 +13,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "lib": ["es5"],
+    "lib": ["es2018"],
     "outDir": "dist"
   },
   "include": [


### PR DESCRIPTION
- Update typescript `target` and `lib` to es2018 as this is the latest supported version by NodeJS LTS 
- Fix typos
- Add missing `.eslintrc` for notification service. Now all services have the same eslint configuration.