### PR TITLE
liquibase: Add retrying of update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,10 @@ services:
       DATABASE_NAME: ods
       DATABASE_USER: ods_admin
       DATABASE_PW: ods_pw
+      CONNECTION_RETRIES: 5
+      CONNECTION_BACKOFF_IN_SECONDS: 2
+    depends_on:
+      - storage-db
 
   storage-swagger: # API documentation for storage service
     image: swaggerapi/swagger-ui

--- a/storage/liquibase/Dockerfile
+++ b/storage/liquibase/Dockerfile
@@ -1,6 +1,8 @@
 FROM webdevops/liquibase:postgres
 
 USER root
+ENV CONNECTION_RETRIES=5
+ENV CONNECTION_BACKOFF_IN_SECONDS=2
 ENV DATABASE_URL=$LIQUIBASE_URL
 
 COPY ./changelog.xml /liquibase/changelog.xml

--- a/storage/liquibase/entrypoint.sh
+++ b/storage/liquibase/entrypoint.sh
@@ -6,7 +6,11 @@ export LIQUIBASE_USERNAME="${DATABASE_USER}"
 export LIQUIBASE_PASSWORD="${DATABASE_PW}"
 
 printf 'Waiting for %s to be ready\n' "${DATABASE_URL}"
-sleep 5 # if db is started for first try it has to apply some changes itself before being available
-printf 'Try to perform liquibase update!\n'
-
-/entrypoint update
+for (( i=0; i<${CONNECTION_RETRIES}; i++ )); do
+  sleep ${CONNECTION_BACKOFF_IN_SECONDS} # if db is started for first try it has to apply some changes itself before being available
+  printf 'Try to perform liquibase update!\n'
+  /entrypoint update
+  if [ $? == "0" ]; then
+    break # Liquibase update was successful
+  fi
+done


### PR DESCRIPTION
### Issue
When running `docker-compose up -d` I often had the problem, that the execution of liquibase failed, because the postgres database was not yet fully setup. This would then lead to further problems as the `storage` and the `storage-mq` service can not access the database because their database users are created by liquibase.

### Fix
This PR fixes this issue by adding retry functionality to the liquibase docker container. If the liquibase update is failing, it will now be retried after a short sleep. The maximal number of connection retries and the sleep duration can be changed with the `CONNECTION_RETRIES` and `CONNECTION_BACKOFF_IN_SECONDS` environment variables.