### PR TITLE
WIP: Validate REST input for transformation service

### DIFF
--- a/adapter/integration-test/package.json
+++ b/adapter/integration-test/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "mock": "node src/mock.server.js",
     "pretest": "npm run mock &",
-    "test": "jest",
+    "test": "jest --runInBand",
     "posttest": "killall node",
     "lint": "./node_modules/.bin/eslint src --ext .js --fix"
   },

--- a/transformation/integration-test/Dockerfile
+++ b/transformation/integration-test/Dockerfile
@@ -1,10 +1,11 @@
 FROM node:lts-alpine as builder
 
-COPY ./src ./src
 COPY ./package*.json ./
-COPY ./.eslintrc ./
-
 RUN npm ci
+
+COPY ./.eslintrc ./
+COPY ./src ./src
+
 RUN npm run lint
 
 EXPOSE 8080

--- a/transformation/integration-test/package.json
+++ b/transformation/integration-test/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Transformation Service Integration-Tests",
   "scripts": {
-    "test": "jest",
+    "test": "jest --runInBand",
     "lint": "./node_modules/.bin/eslint src --ext .js --fix",
     "lint-ci": "./node_modules/.bin/eslint src --ext .js --max-warnings=0"
   },

--- a/transformation/src/api/amqp/pipelineConfigConsumer.ts
+++ b/transformation/src/api/amqp/pipelineConfigConsumer.ts
@@ -1,6 +1,6 @@
 import * as AMQP from 'amqplib'
 import { PipelineConfigManager } from '../../pipeline-config/pipelineConfigManager'
-import pipelineConfigTriggerRequest from '../pipelineConfigTriggerRequest'
+import { PipelineConfigTriggerRequest } from '../pipelineConfigTriggerRequest'
 import {
   AMQP_URL,
   AMQP_DATASOURCE_EXECUTION_EXCHANGE,
@@ -70,7 +70,7 @@ export class PipelineConfigConsumer {
     } else {
       console.debug("[ConsumingEvent] %s:'%s'", msg.fields.routingKey, msg.content.toString())
       if (msg.fields.routingKey === AMQP_DATASOURCE_EXECUTION_SUCCESS_TOPIC) {
-        const triggerRequest: pipelineConfigTriggerRequest = JSON.parse(msg.content.toString())
+        const triggerRequest: PipelineConfigTriggerRequest = JSON.parse(msg.content.toString())
         await this.pipelineManager.triggerConfig(triggerRequest.datasourceId, triggerRequest.data)
       } else {
         console.debug('Received unsubscribed event on topic %s - doing nothing', msg.fields.routingKey)

--- a/transformation/src/api/pipelineConfigTriggerRequest.test.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.test.ts
@@ -1,21 +1,67 @@
 /* eslint-env jest */
 import { PipelineConfigTriggerRequestValidator } from './pipelineConfigTriggerRequest'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const validTriggerRequest = (): any => ({
+  datasourceId: 123,
+  data: {},
+  dataLocation: 'foo'
+})
+
 describe('PipelineConfigTriggerRequestValidator', () => {
-  test('should reject invalid trigger request', () => {
-    const validator = new PipelineConfigTriggerRequestValidator()
+  let validator: PipelineConfigTriggerRequestValidator
+
+  beforeAll(() => {
+    validator = new PipelineConfigTriggerRequestValidator()
+  })
+
+  test('should reject undefined', () => {
     expect(validator.validate(undefined)).toBeFalsy()
+  })
+
+  test('should reject empty object and array', () => {
     expect(validator.validate([])).toBeFalsy()
     expect(validator.validate({})).toBeFalsy()
-    expect(validator.validate({ datasourceId: 'bar' })).toBeFalsy()
-    expect(validator.validate({ datasourceId: 123, data: 'foo' })).toBeFalsy()
-    expect(validator.validate({ datasourceId: 123, data: 'foo' })).toBeFalsy()
+  })
+
+  test('should reject missing or invalid datasourceId', () => {
+    const missingDatasourceIdRequest = validTriggerRequest()
+    delete missingDatasourceIdRequest.datasourceId
+    expect(validator.validate(missingDatasourceIdRequest)).toBeFalsy()
+
+    const invalidDatasourceIdRequest = validTriggerRequest()
+    invalidDatasourceIdRequest.datasourceId = ''
+    expect(validator.validate(invalidDatasourceIdRequest)).toBeFalsy()
+  })
+
+  test('should reject invalid data', () => {
+    const invalidDataRequest = validTriggerRequest()
+    invalidDataRequest.data = 123
+    expect(validator.validate(invalidDataRequest)).toBeFalsy()
+  })
+
+  test('should reject invalid dataLocation', () => {
+    const invalidDataLocationRequest = validTriggerRequest()
+    invalidDataLocationRequest.dataLocation = 123
+    expect(validator.validate(invalidDataLocationRequest)).toBeFalsy()
+  })
+
+  test('should reject missing data and dataLocation', () => {
+    const invalidRequest = validTriggerRequest()
+    delete invalidRequest.data
+    delete invalidRequest.dataLocation
+    expect(validator.validate(invalidRequest)).toBeFalsy()
   })
 
   test('should accept valid trigger request', () => {
-    const validator = new PipelineConfigTriggerRequestValidator()
-    expect(validator.validate({ datasourceId: 123, data: {} })).toBeTruthy()
-    expect(validator.validate({ datasourceId: 123, dataLocation: 'foo' })).toBeTruthy()
-    expect(validator.validate({ datasourceId: 123, data: {}, dataLocation: 'foo' })).toBeTruthy()
+    expect(validator.validate(validTriggerRequest())).toBeTruthy()
+
+    const requestWithMissingData = validTriggerRequest()
+    delete requestWithMissingData.data
+    expect(validator.validate(requestWithMissingData)).toBeTruthy()
+
+    const requestWithMissingDataLocation = validTriggerRequest()
+    delete requestWithMissingDataLocation.dataLocation
+    expect(validator.validate(requestWithMissingDataLocation)).toBeTruthy()
   })
 })

--- a/transformation/src/api/pipelineConfigTriggerRequest.test.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.test.ts
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+import { PipelineConfigTriggerRequestValidator } from './pipelineConfigTriggerRequest'
+
+describe('PipelineConfigTriggerRequestValidator', () => {
+  test('should reject invalid trigger request', () => {
+    const validator = new PipelineConfigTriggerRequestValidator()
+    expect(validator.validate(undefined)).toBeFalsy()
+    expect(validator.validate([])).toBeFalsy()
+    expect(validator.validate({})).toBeFalsy()
+    expect(validator.validate({ datasourceId: 'bar' })).toBeFalsy()
+    expect(validator.validate({ datasourceId: 123, data: 'foo' })).toBeFalsy()
+    expect(validator.validate({ datasourceId: 123, data: 'foo' })).toBeFalsy()
+  })
+
+  test('should accept valid trigger request', () => {
+    const validator = new PipelineConfigTriggerRequestValidator()
+    expect(validator.validate({ datasourceId: 123, data: {} })).toBeTruthy()
+    expect(validator.validate({ datasourceId: 123, dataLocation: 'foo' })).toBeTruthy()
+    expect(validator.validate({ datasourceId: 123, data: {}, dataLocation: 'foo' })).toBeTruthy()
+  })
+})

--- a/transformation/src/api/pipelineConfigTriggerRequest.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.ts
@@ -1,4 +1,4 @@
-import { isObject, isNumber, isString } from '../validators'
+import { isObject, isNumber, isString, hasProperty } from '../validators'
 
 export interface PipelineConfigTriggerRequest {
   datasourceId: number;
@@ -10,25 +10,24 @@ export interface PipelineConfigTriggerRequest {
 export class PipelineConfigTriggerRequestValidator {
   private errors: string[] = []
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  validate (requestBody: any): requestBody is PipelineConfigTriggerRequest {
+  validate (requestBody: unknown): requestBody is PipelineConfigTriggerRequest {
     this.errors = []
     if (!isObject(requestBody)) {
       this.errors.push('\'PipelineConfigTriggerRequest\' must be an object')
       return false
     }
-    if (!('datasourceId' in requestBody)) {
+    if (!hasProperty(requestBody, 'datasourceId')) {
       this.errors.push('\'datasourceId\' property is missing')
     } else if (!isNumber(requestBody.datasourceId)) {
       this.errors.push('\'datasourceId\' must be a number')
     }
-    if ('data' in requestBody && !isObject(requestBody.data)) {
+    if (hasProperty(requestBody, 'data') && !isObject(requestBody.data)) {
       this.errors.push('\'data\' must be an object or array')
     }
-    if ('dataLocation' in requestBody && !isString(requestBody.dataLocation)) {
+    if (hasProperty(requestBody, 'dataLocation') && !isString(requestBody.dataLocation)) {
       this.errors.push('\'dataLocation\' must be a string')
     }
-    if (!('data' in requestBody) && !('dataLocation' in requestBody)) {
+    if (!hasProperty(requestBody, 'data') && !hasProperty(requestBody, 'dataLocation')) {
       this.errors.push('either \'data\' or \'dataLocation\' must be present')
     }
     return this.errors.length === 0

--- a/transformation/src/api/pipelineConfigTriggerRequest.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.ts
@@ -11,6 +11,10 @@ export class PipelineConfigTriggerRequestValidator {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   validate (requestBody: any): requestBody is PipelineConfigTriggerRequest {
     this.errors = []
+    if (typeof requestBody !== 'object') {
+      this.errors.push('\'PipelineConfigTriggerRequest\' must be an object')
+      return false
+    }
     if (!('datasourceId' in requestBody)) {
       this.errors.push('\'datasourceId\' property is missing')
     } else if (!(typeof requestBody.datasourceId === 'number')) {

--- a/transformation/src/api/pipelineConfigTriggerRequest.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.ts
@@ -1,3 +1,5 @@
+import { isObject, isNumber, isString } from '../validators'
+
 export interface PipelineConfigTriggerRequest {
   datasourceId: number;
 
@@ -11,19 +13,19 @@ export class PipelineConfigTriggerRequestValidator {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   validate (requestBody: any): requestBody is PipelineConfigTriggerRequest {
     this.errors = []
-    if (typeof requestBody !== 'object') {
+    if (!isObject(requestBody)) {
       this.errors.push('\'PipelineConfigTriggerRequest\' must be an object')
       return false
     }
     if (!('datasourceId' in requestBody)) {
       this.errors.push('\'datasourceId\' property is missing')
-    } else if (typeof requestBody.datasourceId !== 'number') {
+    } else if (!isNumber(requestBody.datasourceId)) {
       this.errors.push('\'datasourceId\' must be a number')
     }
-    if ('data' in requestBody && typeof requestBody.data !== 'object') {
+    if ('data' in requestBody && !isObject(requestBody.data)) {
       this.errors.push('\'data\' must be an object or array')
     }
-    if ('dataLocation' in requestBody && typeof requestBody.dataLocation !== 'string') {
+    if ('dataLocation' in requestBody && !isString(requestBody.dataLocation)) {
       this.errors.push('\'dataLocation\' must be a string')
     }
     if (!('data' in requestBody) && !('dataLocation' in requestBody)) {

--- a/transformation/src/api/pipelineConfigTriggerRequest.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.ts
@@ -1,6 +1,34 @@
-export default interface PipelineConfigTriggerRequest {
+export interface PipelineConfigTriggerRequest {
   datasourceId: number;
 
   data: object;
   dataLocation: string;
+}
+
+export class PipelineConfigTriggerRequestValidator {
+  private errors: string[] = []
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  validate (requestBody: any): requestBody is PipelineConfigTriggerRequest {
+    this.errors = []
+    if (!('datasourceId' in requestBody)) {
+      this.errors.push('\'datasourceId\' property is missing')
+    } else if (!(typeof requestBody.datasourceId === 'number')) {
+      this.errors.push('\'datasourceId\' must be a number')
+    }
+    if ('data' in requestBody && !(typeof requestBody.data === 'object')) {
+      this.errors.push('\'data\' must be an object or array')
+    }
+    if ('dataLocation' in requestBody && !(typeof requestBody.dataLocation === 'string')) {
+      this.errors.push('\'dataLocation\' must be a string')
+    }
+    if (!('data' in requestBody) && !('dataLocation' in requestBody)) {
+      this.errors.push('either \'data\' or \'dataLocation\' must be present')
+    }
+    return this.errors.length === 0
+  }
+
+  getErrors (): string[] {
+    return this.errors
+  }
 }

--- a/transformation/src/api/pipelineConfigTriggerRequest.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.ts
@@ -17,13 +17,13 @@ export class PipelineConfigTriggerRequestValidator {
     }
     if (!('datasourceId' in requestBody)) {
       this.errors.push('\'datasourceId\' property is missing')
-    } else if (!(typeof requestBody.datasourceId === 'number')) {
+    } else if (typeof requestBody.datasourceId !== 'number') {
       this.errors.push('\'datasourceId\' must be a number')
     }
-    if ('data' in requestBody && !(typeof requestBody.data === 'object')) {
+    if ('data' in requestBody && typeof requestBody.data !== 'object') {
       this.errors.push('\'data\' must be an object or array')
     }
-    if ('dataLocation' in requestBody && !(typeof requestBody.dataLocation === 'string')) {
+    if ('dataLocation' in requestBody && typeof requestBody.dataLocation !== 'string') {
       this.errors.push('\'dataLocation\' must be a string')
     }
     if (!('data' in requestBody) && !('dataLocation' in requestBody)) {

--- a/transformation/src/api/rest/pipelineConfigEndpoint.ts
+++ b/transformation/src/api/rest/pipelineConfigEndpoint.ts
@@ -2,8 +2,8 @@ import * as express from 'express'
 import axios from 'axios'
 
 import { PipelineConfigTriggerRequestValidator } from '../pipelineConfigTriggerRequest'
-import { PipelineConfigManager } from '../../pipeline-config/pipelineConfigManager'
-import PipelineConfig from '@/pipeline-config/model/pipelineConfig'
+import { PipelineConfigManager } from '@/pipeline-config/pipelineConfigManager'
+import { PipelineConfig } from '@/pipeline-config/model/pipelineConfig'
 
 export class PipelineConfigEndpoint {
   pipelineConfigManager: PipelineConfigManager
@@ -75,7 +75,7 @@ export class PipelineConfigEndpoint {
       res.status(400).send('Path parameter id is missing or is incorrect')
       return
     }
-    const config = req.body as PipelineConfig
+    const config = req.body as PipelineConfig // TODO validate input
     if (!config.transformation) {
       config.transformation = { func: 'return data;' }
     }

--- a/transformation/src/api/rest/pipelineConfigEndpoint.ts
+++ b/transformation/src/api/rest/pipelineConfigEndpoint.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 
 import { PipelineConfigTriggerRequestValidator } from '../pipelineConfigTriggerRequest'
 import { PipelineConfigManager } from '@/pipeline-config/pipelineConfigManager'
-import { PipelineConfigValidator } from '@/pipeline-config/model/pipelineConfig'
+import { PipelineConfigDTOValidator } from '../../pipeline-config/model/pipelineConfig'
 
 export class PipelineConfigEndpoint {
   pipelineConfigManager: PipelineConfigManager
@@ -72,7 +72,7 @@ export class PipelineConfigEndpoint {
       res.status(400).send('Path parameter id is missing or is incorrect')
       return
     }
-    const validator = new PipelineConfigValidator()
+    const validator = new PipelineConfigDTOValidator()
     if (!validator.validate(req.body)) {
       res.status(400).json({ errors: validator.getErrors() })
       return
@@ -89,7 +89,7 @@ export class PipelineConfigEndpoint {
   }
 
   create = async (req: express.Request, res: express.Response): Promise<void> => {
-    const validator = new PipelineConfigValidator()
+    const validator = new PipelineConfigDTOValidator()
     if (!validator.validate(req.body)) {
       res.status(400).json({ errors: validator.getErrors() })
       return

--- a/transformation/src/pipeline-config/model/pipelineConfig.test.ts
+++ b/transformation/src/pipeline-config/model/pipelineConfig.test.ts
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+import { PipelineConfigDTO, PipelineConfigDTOValidator } from './pipelineConfig'
+
+const validPipelineConfig = (): PipelineConfigDTO => ({
+  datasourceId: 1,
+  transformation: {
+    func: 'return data+data;'
+  },
+  metadata: {
+    author: 'icke',
+    license: 'none',
+    displayName: 'test pipeline',
+    description: 'integration testing pipeline'
+  }
+})
+
+describe('PipelineConfigDTOValidator', () => {
+  test('should reject invalid pipeline config', () => {
+    const validator = new PipelineConfigDTOValidator()
+    expect(validator.validate(undefined)).toBeFalsy()
+    expect(validator.validate([])).toBeFalsy()
+    expect(validator.validate({})).toBeFalsy()
+    expect(validator.validate({ datasourceId: 1 })).toBeFalsy()
+    expect(validator.validate({ metadata: { author: 'icke' } })).toBeFalsy()
+    expect(validator.validate({ datasourceId: 1, metadata: { author: 123 } })).toBeFalsy()
+    expect(validator.validate({ datasourceId: 1, metadata: { author: 'icke', license: 'foo' } })).toBeFalsy()
+    const config = validPipelineConfig()
+    delete config.transformation.func
+    expect(validator.validate(config)).toBeFalsy()
+  })
+
+  test('should add default identity transformation function', () => {
+    const validator = new PipelineConfigDTOValidator()
+    const pipelineConfig = validPipelineConfig()
+    delete pipelineConfig.transformation
+    if (validator.validate(pipelineConfig)) {
+      expect(pipelineConfig.transformation.func).toBe('return data;')
+    } else {
+      expect(true).toBeFalsy()
+    }
+  })
+
+  test('should accept valid pipeline config', () => {
+    const validator = new PipelineConfigDTOValidator()
+    expect(validator.validate(validPipelineConfig())).toBeTruthy()
+  })
+})

--- a/transformation/src/pipeline-config/model/pipelineConfig.ts
+++ b/transformation/src/pipeline-config/model/pipelineConfig.ts
@@ -17,21 +17,28 @@ export interface Metadata {
   creationTimestamp: Date;
 }
 
-export class PipelineConfigValidator {
+export interface PipelineConfigDTO {
+  datasourceId: number;
+  transformation: TransformationConfig;
+  metadata: MetadataDTO;
+}
+
+export interface MetadataDTO {
+  author: string;
+  displayName: string;
+  license: string;
+  description: string;
+}
+
+export class PipelineConfigDTOValidator {
   private errors: string[] = []
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  validate (pipelineConfig: any): pipelineConfig is PipelineConfig {
+  validate (pipelineConfig: any): pipelineConfig is PipelineConfigDTO {
     this.errors = []
     if (typeof pipelineConfig !== 'object') {
       this.errors.push('\'PipelineConfig\' must be an object')
       return false
-    }
-
-    if (!('id' in pipelineConfig)) {
-      this.errors.push('\'id\' property is missing')
-    } else if (typeof pipelineConfig.id !== 'number') {
-      this.errors.push('\'id\' property must be a number')
     }
 
     if (!('datasourceId' in pipelineConfig)) {
@@ -81,14 +88,6 @@ export class PipelineConfigValidator {
       } else if (typeof pipelineConfig.metadata.description !== 'string') {
         this.errors.push('\'metadata.description\' property must be a string')
       }
-
-      if (!('creationTimestamp' in pipelineConfig.metadata)) {
-        this.errors.push('\'metadata.creationTimestamp\' property is missing')
-      }/* else if (typeof metadata.creationTimestamp !== 'object') {
-        this.errors.push('\'metadata.creationTimestamp\' property must be an object')
-      }
-      */
-      // ToDo: proper date checking
     }
 
     return this.errors.length === 0

--- a/transformation/src/pipeline-config/model/pipelineConfig.ts
+++ b/transformation/src/pipeline-config/model/pipelineConfig.ts
@@ -1,4 +1,4 @@
-import { isObject, isString, isNumber } from '../../validators'
+import { isObject, isString, isNumber, hasProperty } from '../../validators'
 
 export interface PipelineConfig {
   id: number;
@@ -38,57 +38,57 @@ export interface MetadataDTO {
 export class PipelineConfigDTOValidator {
   private errors: string[] = []
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  validate (pipelineConfig: any): pipelineConfig is PipelineConfigDTO {
+  validate (pipelineConfig: unknown): pipelineConfig is PipelineConfigDTO {
     this.errors = []
     if (!isObject(pipelineConfig)) {
       this.errors.push('\'PipelineConfig\' must be an object')
       return false
     }
 
-    if (!('datasourceId' in pipelineConfig)) {
+    if (!hasProperty(pipelineConfig, 'datasourceId')) {
       this.errors.push('\'datasourceId\' property is missing')
     } else if (!isNumber(pipelineConfig.datasourceId)) {
       this.errors.push('\'datasourceId\' property must be a number')
     }
 
-    if (!('transformation' in pipelineConfig)) {
+    if (!hasProperty(pipelineConfig, 'transformation')) {
       // Missing transformation is not an error, assume identity transformation
-      pipelineConfig.transformation = { func: 'return data;' }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (pipelineConfig as any).transformation = { func: 'return data;' }
     } else if (!isObject(pipelineConfig.transformation)) {
       this.errors.push('\'transformation\' property must be an object')
     } else {
-      if (!('func' in pipelineConfig.transformation)) {
+      if (!hasProperty(pipelineConfig.transformation, 'func')) {
         this.errors.push('\'transformation.func\' property is missing')
       } else if (!isString(pipelineConfig.transformation.func)) {
         this.errors.push('\'transformation.func\' property must be a string')
       }
     }
 
-    if (!('metadata' in pipelineConfig)) {
+    if (!hasProperty(pipelineConfig, 'metadata')) {
       this.errors.push('\'metadata\' property is missing')
     } else if (!isObject(pipelineConfig.metadata)) {
       this.errors.push('\'metadata\' property must be an object')
     } else {
-      if (!('author' in pipelineConfig.metadata)) {
+      if (!hasProperty(pipelineConfig.metadata, 'author')) {
         this.errors.push('\'metadata.author\' property is missing')
       } else if (!isString(pipelineConfig.metadata.author)) {
         this.errors.push('\'metadata.author\' property must be a string')
       }
 
-      if (!('displayName' in pipelineConfig.metadata)) {
+      if (!hasProperty(pipelineConfig.metadata, 'displayName')) {
         this.errors.push('\'metadata.displayName\' property is missing')
       } else if (!isString(pipelineConfig.metadata.displayName)) {
         this.errors.push('\'metadata.displayName\' property must be a string')
       }
 
-      if (!('license' in pipelineConfig.metadata)) {
+      if (!hasProperty(pipelineConfig.metadata, 'license')) {
         this.errors.push('\'metadata.license\' property is missing')
       } else if (!isString(pipelineConfig.metadata.license)) {
         this.errors.push('\'metadata.license\' property must be a string')
       }
 
-      if (!('description' in pipelineConfig.metadata)) {
+      if (!hasProperty(pipelineConfig.metadata, 'description')) {
         this.errors.push('\'metadata.description\' property is missing')
       } else if (!isString(pipelineConfig.metadata.description)) {
         this.errors.push('\'metadata.description\' property must be a string')

--- a/transformation/src/pipeline-config/model/pipelineConfig.ts
+++ b/transformation/src/pipeline-config/model/pipelineConfig.ts
@@ -1,3 +1,5 @@
+import { isObject, isString, isNumber } from '../../validators'
+
 export interface PipelineConfig {
   id: number;
   datasourceId: number;
@@ -17,6 +19,9 @@ export interface Metadata {
   creationTimestamp: Date;
 }
 
+/**
+ * PipelineConfig data transfer object that clients must use when creating or updating a PipelineConfig
+ */
 export interface PipelineConfigDTO {
   datasourceId: number;
   transformation: TransformationConfig;
@@ -36,56 +41,56 @@ export class PipelineConfigDTOValidator {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   validate (pipelineConfig: any): pipelineConfig is PipelineConfigDTO {
     this.errors = []
-    if (typeof pipelineConfig !== 'object') {
+    if (!isObject(pipelineConfig)) {
       this.errors.push('\'PipelineConfig\' must be an object')
       return false
     }
 
     if (!('datasourceId' in pipelineConfig)) {
       this.errors.push('\'datasourceId\' property is missing')
-    } else if (typeof pipelineConfig.datasourceId !== 'number') {
+    } else if (!isNumber(pipelineConfig.datasourceId)) {
       this.errors.push('\'datasourceId\' property must be a number')
     }
 
     if (!('transformation' in pipelineConfig)) {
       // Missing transformation is not an error, assume identity transformation
       pipelineConfig.transformation = { func: 'return data;' }
-    } else if (typeof pipelineConfig.transformation !== 'object') {
+    } else if (!isObject(pipelineConfig.transformation)) {
       this.errors.push('\'transformation\' property must be an object')
     } else {
       if (!('func' in pipelineConfig.transformation)) {
         this.errors.push('\'transformation.func\' property is missing')
-      } else if (typeof pipelineConfig.transformation.func !== 'string') {
+      } else if (!isString(pipelineConfig.transformation.func)) {
         this.errors.push('\'transformation.func\' property must be a string')
       }
     }
 
     if (!('metadata' in pipelineConfig)) {
       this.errors.push('\'metadata\' property is missing')
-    } else if (typeof pipelineConfig.metadata !== 'object') {
+    } else if (!isObject(pipelineConfig.metadata)) {
       this.errors.push('\'metadata\' property must be an object')
     } else {
       if (!('author' in pipelineConfig.metadata)) {
         this.errors.push('\'metadata.author\' property is missing')
-      } else if (typeof pipelineConfig.metadata.author !== 'string') {
+      } else if (!isString(pipelineConfig.metadata.author)) {
         this.errors.push('\'metadata.author\' property must be a string')
       }
 
       if (!('displayName' in pipelineConfig.metadata)) {
         this.errors.push('\'metadata.displayName\' property is missing')
-      } else if (typeof pipelineConfig.metadata.displayName !== 'string') {
+      } else if (!isString(pipelineConfig.metadata.displayName)) {
         this.errors.push('\'metadata.displayName\' property must be a string')
       }
 
       if (!('license' in pipelineConfig.metadata)) {
         this.errors.push('\'metadata.license\' property is missing')
-      } else if (typeof pipelineConfig.metadata.license !== 'string') {
+      } else if (!isString(pipelineConfig.metadata.license)) {
         this.errors.push('\'metadata.license\' property must be a string')
       }
 
       if (!('description' in pipelineConfig.metadata)) {
         this.errors.push('\'metadata.description\' property is missing')
-      } else if (typeof pipelineConfig.metadata.description !== 'string') {
+      } else if (!isString(pipelineConfig.metadata.description)) {
         this.errors.push('\'metadata.description\' property must be a string')
       }
     }

--- a/transformation/src/pipeline-config/model/pipelineConfig.ts
+++ b/transformation/src/pipeline-config/model/pipelineConfig.ts
@@ -1,4 +1,4 @@
-export default interface PipelineConfig {
+export interface PipelineConfig {
   id: number;
   datasourceId: number;
   transformation: TransformationConfig;

--- a/transformation/src/pipeline-config/model/pipelineConfig.ts
+++ b/transformation/src/pipeline-config/model/pipelineConfig.ts
@@ -16,3 +16,85 @@ export interface Metadata {
   description: string;
   creationTimestamp: Date;
 }
+
+export class PipelineConfigValidator {
+  private errors: string[] = []
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  validate (pipelineConfig: any): pipelineConfig is PipelineConfig {
+    this.errors = []
+    if (typeof pipelineConfig !== 'object') {
+      this.errors.push('\'PipelineConfig\' must be an object')
+      return false
+    }
+
+    if (!('id' in pipelineConfig)) {
+      this.errors.push('\'id\' property is missing')
+    } else if (typeof pipelineConfig.id !== 'number') {
+      this.errors.push('\'id\' property must be a number')
+    }
+
+    if (!('datasourceId' in pipelineConfig)) {
+      this.errors.push('\'datasourceId\' property is missing')
+    } else if (typeof pipelineConfig.datasourceId !== 'number') {
+      this.errors.push('\'datasourceId\' property must be a number')
+    }
+
+    if (!('transformation' in pipelineConfig)) {
+      // Missing transformation is not an error, assume identity transformation
+      pipelineConfig.transformation = { func: 'return data;' }
+    } else if (typeof pipelineConfig.transformation !== 'object') {
+      this.errors.push('\'transformation\' property must be an object')
+    } else {
+      if (!('func' in pipelineConfig.transformation)) {
+        this.errors.push('\'transformation.func\' property is missing')
+      } else if (typeof pipelineConfig.transformation.func !== 'string') {
+        this.errors.push('\'transformation.func\' property must be a string')
+      }
+    }
+
+    if (!('metadata' in pipelineConfig)) {
+      this.errors.push('\'metadata\' property is missing')
+    } else if (typeof pipelineConfig.metadata !== 'object') {
+      this.errors.push('\'metadata\' property must be an object')
+    } else {
+      if (!('author' in pipelineConfig.metadata)) {
+        this.errors.push('\'metadata.author\' property is missing')
+      } else if (typeof pipelineConfig.metadata.author !== 'string') {
+        this.errors.push('\'metadata.author\' property must be a string')
+      }
+
+      if (!('displayName' in pipelineConfig.metadata)) {
+        this.errors.push('\'metadata.displayName\' property is missing')
+      } else if (typeof pipelineConfig.metadata.displayName !== 'string') {
+        this.errors.push('\'metadata.displayName\' property must be a string')
+      }
+
+      if (!('license' in pipelineConfig.metadata)) {
+        this.errors.push('\'metadata.license\' property is missing')
+      } else if (typeof pipelineConfig.metadata.license !== 'string') {
+        this.errors.push('\'metadata.license\' property must be a string')
+      }
+
+      if (!('description' in pipelineConfig.metadata)) {
+        this.errors.push('\'metadata.description\' property is missing')
+      } else if (typeof pipelineConfig.metadata.description !== 'string') {
+        this.errors.push('\'metadata.description\' property must be a string')
+      }
+
+      if (!('creationTimestamp' in pipelineConfig.metadata)) {
+        this.errors.push('\'metadata.creationTimestamp\' property is missing')
+      }/* else if (typeof metadata.creationTimestamp !== 'object') {
+        this.errors.push('\'metadata.creationTimestamp\' property must be an object')
+      }
+      */
+      // ToDo: proper date checking
+    }
+
+    return this.errors.length === 0
+  }
+
+  getErrors (): string[] {
+    return this.errors
+  }
+}

--- a/transformation/src/pipeline-config/pipelineConfigManager.test.ts
+++ b/transformation/src/pipeline-config/pipelineConfigManager.test.ts
@@ -6,7 +6,7 @@ import PipelineConfigRepository from './pipelineConfigRepository'
 import { PipelineConfigManager } from './pipelineConfigManager'
 import PipelineExecutor from '../pipeline-execution/pipelineExecutor'
 import { ExecutionResultPublisher } from './publisher/executionResultPublisher'
-import { PipelineConfig } from './model/pipelineConfig'
+import { PipelineConfig, PipelineConfigDTO } from './model/pipelineConfig'
 import VM2SandboxExecutor from '../pipeline-execution/sandbox/vm2SandboxExecutor'
 
 jest.mock('../pipeline-execution/pipelineExecutor')
@@ -28,6 +28,21 @@ const generateConfig = (): PipelineConfig => {
       license: 'Test License',
       description: 'A test pipeline.',
       creationTimestamp: new Date()
+    }
+  }
+}
+
+const pipelineConfigDTO = (): PipelineConfigDTO => {
+  return {
+    datasourceId: 456,
+    transformation: {
+      func: 'return data;'
+    },
+    metadata: {
+      author: 'author',
+      displayName: 'Pipeline Test',
+      license: 'Test License',
+      description: 'A test pipeline.'
     }
   }
 }
@@ -58,7 +73,7 @@ afterEach(() => {
 })
 
 test('Should call create and publish event', async () => {
-  const config = generateConfig()
+  const config = pipelineConfigDTO()
 
   const repositoryMock = new RepositoryMock()
   const writesPublisherMock = new WritesPublisherMock()
@@ -76,7 +91,7 @@ test('Should call create and publish event', async () => {
 })
 
 test('Should call update and publish event', async () => {
-  const config = generateConfig()
+  const config = pipelineConfigDTO()
 
   const repositoryMock = new RepositoryMock()
   const writesPublisherMock = new WritesPublisherMock()
@@ -87,15 +102,13 @@ test('Should call update and publish event', async () => {
     writesPublisherMock,
     new ExecutionPublisherMock()
   )
-  await manager.update(config.id, config)
+  await manager.update(123, config)
 
-  expect(repositoryMock.update).toHaveBeenCalledWith(config.id, config)
+  expect(repositoryMock.update).toHaveBeenCalledWith(123, config)
   expect(writesPublisherMock.publishUpdate).toHaveBeenCalledTimes(1)
 })
 
 test('Should call delete and publish event', async () => {
-  const config = generateConfig()
-
   const repositoryMock = new RepositoryMock()
   const writesPublisherMock = new WritesPublisherMock()
 
@@ -105,9 +118,9 @@ test('Should call delete and publish event', async () => {
     writesPublisherMock,
     new ExecutionPublisherMock()
   )
-  await manager.delete(config.id)
+  await manager.delete(1234)
 
-  expect(repositoryMock.delete).toHaveBeenCalledWith(config.id)
+  expect(repositoryMock.delete).toHaveBeenCalledWith(1234)
   expect(writesPublisherMock.publishDeletion).toHaveBeenCalledTimes(1)
 })
 

--- a/transformation/src/pipeline-config/pipelineConfigManager.test.ts
+++ b/transformation/src/pipeline-config/pipelineConfigManager.test.ts
@@ -6,7 +6,7 @@ import PipelineConfigRepository from './pipelineConfigRepository'
 import { PipelineConfigManager } from './pipelineConfigManager'
 import PipelineExecutor from '../pipeline-execution/pipelineExecutor'
 import { ExecutionResultPublisher } from './publisher/executionResultPublisher'
-import PipelineConfig from './model/pipelineConfig'
+import { PipelineConfig } from './model/pipelineConfig'
 import VM2SandboxExecutor from '../pipeline-execution/sandbox/vm2SandboxExecutor'
 
 jest.mock('../pipeline-execution/pipelineExecutor')

--- a/transformation/src/pipeline-config/pipelineConfigManager.ts
+++ b/transformation/src/pipeline-config/pipelineConfigManager.ts
@@ -1,7 +1,7 @@
 import PipelineExecutor from '../pipeline-execution/pipelineExecutor'
 import { ExecutionResultPublisher } from './publisher/executionResultPublisher'
 import PipelineConfigRepository from './pipelineConfigRepository'
-import { PipelineConfig } from './model/pipelineConfig'
+import { PipelineConfig, PipelineConfigDTO } from './model/pipelineConfig'
 import ConfigWritesPublisher from './publisher/configWritesPublisher'
 
 export class PipelineConfigManager {
@@ -22,7 +22,7 @@ export class PipelineConfigManager {
     this.executionResultPublisher = executionResultPublisher
   }
 
-  async create (config: PipelineConfig): Promise<PipelineConfig> {
+  async create (config: PipelineConfigDTO): Promise<PipelineConfig> {
     const savedConfig = await this.pipelineConfigRepository.create(config)
     const success = this.configWritesPublisher.publishCreation(savedConfig.id, savedConfig.metadata.displayName)
     if (!success) {
@@ -46,7 +46,7 @@ export class PipelineConfigManager {
     return this.pipelineConfigRepository.getByDatasourceId(datasourceId)
   }
 
-  async update (id: number, config: PipelineConfig): Promise<void> {
+  async update (id: number, config: PipelineConfigDTO): Promise<void> {
     await this.pipelineConfigRepository.update(id, config)
     const success = this.configWritesPublisher.publishUpdate(id, config.metadata.displayName)
     if (!success) {

--- a/transformation/src/pipeline-config/pipelineConfigManager.ts
+++ b/transformation/src/pipeline-config/pipelineConfigManager.ts
@@ -1,7 +1,7 @@
 import PipelineExecutor from '../pipeline-execution/pipelineExecutor'
 import { ExecutionResultPublisher } from './publisher/executionResultPublisher'
 import PipelineConfigRepository from './pipelineConfigRepository'
-import PipelineConfig from './model/pipelineConfig'
+import { PipelineConfig } from './model/pipelineConfig'
 import ConfigWritesPublisher from './publisher/configWritesPublisher'
 
 export class PipelineConfigManager {

--- a/transformation/src/pipeline-config/pipelineConfigRepository.ts
+++ b/transformation/src/pipeline-config/pipelineConfigRepository.ts
@@ -1,4 +1,4 @@
-import PipelineConfig from './model/pipelineConfig'
+import { PipelineConfig } from './model/pipelineConfig'
 
 export default interface PipelineConfigRepository {
   create(config: PipelineConfig): Promise<PipelineConfig>;

--- a/transformation/src/pipeline-config/pipelineConfigRepository.ts
+++ b/transformation/src/pipeline-config/pipelineConfigRepository.ts
@@ -1,11 +1,11 @@
-import { PipelineConfig } from './model/pipelineConfig'
+import { PipelineConfig, PipelineConfigDTO } from './model/pipelineConfig'
 
 export default interface PipelineConfigRepository {
-  create(config: PipelineConfig): Promise<PipelineConfig>;
+  create(config: PipelineConfigDTO): Promise<PipelineConfig>;
   get(id: number): Promise<PipelineConfig | undefined>;
   getAll(): Promise<PipelineConfig[]>;
   getByDatasourceId(datasourceId: number): Promise<PipelineConfig[]>;
-  update(id: number, config: PipelineConfig): Promise<void>;
+  update(id: number, config: PipelineConfigDTO): Promise<void>;
   delete(id: number): Promise<PipelineConfig>;
   deleteAll(): Promise<PipelineConfig[]>;
 }

--- a/transformation/src/pipeline-config/postgresPipelineConfigRepository.ts
+++ b/transformation/src/pipeline-config/postgresPipelineConfigRepository.ts
@@ -1,7 +1,7 @@
 import { Pool, PoolConfig, PoolClient, QueryResult } from 'pg'
 
 import { POSTGRES_SCHEMA, POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PW, POSTGRES_DB } from '../env'
-import { PipelineConfig } from './model/pipelineConfig'
+import { PipelineConfig, PipelineConfigDTO } from './model/pipelineConfig'
 import PipelineConfigRepository from './pipelineConfigRepository'
 
 const POSTGRES_TABLE = 'PipelineConfigs'
@@ -160,10 +160,7 @@ export default class PostgresPipelineConfigRepository implements PipelineConfigR
     }
   }
 
-  async create (config: PipelineConfig): Promise<PipelineConfig> {
-    delete config.id // id not under control of client
-    config.metadata.creationTimestamp = new Date()
-
+  async create (config: PipelineConfigDTO): Promise<PipelineConfig> {
     const values = [
       config.datasourceId,
       config.transformation.func,
@@ -171,7 +168,7 @@ export default class PostgresPipelineConfigRepository implements PipelineConfigR
       config.metadata.displayName,
       config.metadata.license,
       config.metadata.description,
-      config.metadata.creationTimestamp
+      new Date()
     ]
     const { rows } = await this.executeQuery(INSERT_STATEMENT, values)
     return Promise.resolve(this.toPipelineConfig(rows[0]))
@@ -198,7 +195,7 @@ export default class PostgresPipelineConfigRepository implements PipelineConfigR
     return Promise.resolve(content)
   }
 
-  async update (id: number, config: PipelineConfig): Promise<void> {
+  async update (id: number, config: PipelineConfigDTO): Promise<void> {
     const values = [
       id,
       config.datasourceId,

--- a/transformation/src/pipeline-config/postgresPipelineConfigRepository.ts
+++ b/transformation/src/pipeline-config/postgresPipelineConfigRepository.ts
@@ -1,7 +1,7 @@
 import { Pool, PoolConfig, PoolClient, QueryResult } from 'pg'
 
 import { POSTGRES_SCHEMA, POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PW, POSTGRES_DB } from '../env'
-import PipelineConfig from './model/pipelineConfig'
+import { PipelineConfig } from './model/pipelineConfig'
 import PipelineConfigRepository from './pipelineConfigRepository'
 
 const POSTGRES_TABLE = 'PipelineConfigs'
@@ -44,8 +44,9 @@ interface DatabasePipeline {
   func: string;
   author: string;
   displayName: string;
-  license: string; description:
-  string; createdAt: Date;
+  license: string;
+  description: string;
+  createdAt: Date;
 }
 
 export default class PostgresPipelineConfigRepository implements PipelineConfigRepository {

--- a/transformation/src/validators.ts
+++ b/transformation/src/validators.ts
@@ -1,14 +1,18 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isNumber (x: any): x is number {
+export function isNumber (x: unknown): x is number {
   return typeof x === 'number'
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isString (x: any): x is string {
+export function isString (x: unknown): x is string {
   return typeof x === 'string'
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isObject (x: any): x is any {
+export function isObject (x: unknown): x is object {
   return typeof x === 'object'
+}
+
+// Helper function to fix issue that `in` operator as type guard is not widening type with the asserted property key
+// See https://github.com/microsoft/TypeScript/issues/21732
+export function hasProperty<P extends PropertyKey, O extends object> (object: O, name: P):
+  object is O & { [K in P]: unknown } {
+  return name in object
 }

--- a/transformation/src/validators.ts
+++ b/transformation/src/validators.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isNumber (x: any): x is number {
+  return typeof x === 'number'
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isString (x: any): x is string {
+  return typeof x === 'string'
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isObject (x: any): x is any {
+  return typeof x === 'object'
+}


### PR DESCRIPTION
Adds REST input validation for the transformation service:

- [x] Refactor transformation integration-test Dockerfile to make use of docker layer caching
- [x] Validation for `PipelineConfigTriggerRequest` model
- [x] Add test cases for `PipelineConfigTriggerRequest` validator
- [x] Validation for `PipelineConfig` model
- [x] Add test cases for `PipelineConfig` validator
- [x] Revert commit c3838c6  "Run integration tests parellely" as IT tests have been very flaky when executing in parallel

Fixes #147 