### PR TITLE
UI: Fix DatasourceEdit and PipelineEdit

### DIFF
--- a/ui/src/datasource/datasource.module.ts
+++ b/ui/src/datasource/datasource.module.ts
@@ -6,7 +6,7 @@ import * as RestService from './datasourceRest'
 export default class DatasourceModule extends VuexModule {
   private datasources: Datasource[] = []
 
-  private selectedDatasource?: Datasource
+  private selectedDatasource?: Datasource = undefined
 
   private isLoadingDatasources = true
 

--- a/ui/src/notification/NotificationOverview.vue
+++ b/ui/src/notification/NotificationOverview.vue
@@ -120,15 +120,14 @@ export default class PipelineNotifications extends Vue {
   private loadConfigbyPipelineIdAction!: (id: number) => void
 
   @Action('addNotification', notificationNameSpace)
-  private addNotificationAction!: (notification: NotificationConfig) => Promise<NotificationConfig[]>
+  private addNotificationAction!: (notification: NotificationConfig) => void
 
   @Action('removeNotification', notificationNameSpace)
-  private removeNotificationAction!: (notification: NotificationConfig) => Promise<NotificationConfig[]>
+  private removeNotificationAction!: (notification: NotificationConfig) => void
 
   @Action('updateNotification', notificationNameSpace)
-  private updateNotificationAction!: (notification: NotificationConfig) => Promise<NotificationConfig[]>
+  private updateNotificationAction!: (notification: NotificationConfig) => void
 
-  // @State('selectedPipeline', pipelineNameSpace) private selectedPipeline!: Pipeline
   @State('notifications', notificationNameSpace) private notifications!: NotificationConfig[]
   @State('isLoadingNotifications', notificationNameSpace) private isLoadingNotifications!: boolean;
 
@@ -145,7 +144,7 @@ export default class PipelineNotifications extends Vue {
   private isEdit = false
   private pipelineId = -1
 
-  private async created () {
+  created (): void {
     console.log('Notification Overview created!')
     this.pipelineId = parseInt(this.$route.params.pipelineId)
     this.loadConfigbyPipelineIdAction(this.pipelineId)
@@ -161,7 +160,7 @@ export default class PipelineNotifications extends Vue {
     this.notificationEdit.openDialog(notification)
   }
 
-  private async onDeleteNotification (notification: NotificationConfig) {
+  private onDeleteNotification (notification: NotificationConfig): void {
     this.removeNotificationAction(notification)
   }
 
@@ -173,7 +172,7 @@ export default class PipelineNotifications extends Vue {
     this.$router.push({ name: 'pipeline-overview' })
   }
 
-  private async onSave (editedNotification: NotificationConfig) {
+  private onSave (editedNotification: NotificationConfig): void {
     editedNotification.pipelineId = this.pipelineId
 
     if (this.isEdit) { // edit

--- a/ui/src/pipeline/pipeline.module.ts
+++ b/ui/src/pipeline/pipeline.module.ts
@@ -5,7 +5,7 @@ import * as RestService from './pipelineRest'
 @Module({ namespaced: true })
 export default class PipelineModule extends VuexModule {
   private pipelines: Pipeline[] = []
-  private selectedPipeline?: Pipeline
+  private selectedPipeline?: Pipeline = undefined
   private isLoadingPipelines = true
 
   @Mutation


### PR DESCRIPTION
~PR #172 introduced a weird bug with `@State` or `@Watch` decorators that they are not working with a value of `undefined` for the `selectedDatasource` and `selectedPipeline` properties in the `VuexModule`. I did not find a simple way of fixing this bug. But I decided to fix this bug by removing the `selectedDatasource` or `selectedPipeline` properties from the `VuexModule` and directly using `datasourceRest.ts` and `pipelineRest.ts` because of three reasons:~
- ~This fixes the bug mentioned above~
- ~Vuex adds a lot of complexity to the UI code~
- ~Caching of the `selectedDatasource` or `selectedPipeline` properties in the VuexModule does not make much sense. It is only used when creating the `DatasourceEdit` or `PipelineEdit` component.~

Fix fixes an issue because I forgot to initialize the properties correctly...