### PR TITLE
Notification: Remove usage of `as` operator

### DIFF
--- a/notification/.eslintrc
+++ b/notification/.eslintrc
@@ -20,6 +20,7 @@
     "@typescript-eslint/no-use-before-define": ["warn", { "functions": false, "classes": true }],
     "max-len": [2, 120, 4, { "ignoreUrls": true }],
     "@typescript-eslint/explicit-function-return-type": [1, { "allowExpressions": true }],
-    "@typescript-eslint/no-floating-promises": "warn"
+    "@typescript-eslint/no-floating-promises": "warn",
+    "@typescript-eslint/consistent-type-assertions": [ "warn", { "assertionStyle": "never" }]
   }
 }

--- a/notification/Dockerfile
+++ b/notification/Dockerfile
@@ -2,14 +2,20 @@
 FROM node:lts-alpine as builder
 
 WORKDIR /build
-COPY ./src ./src
-COPY ./package*.json ./
-COPY ./tsconfig.json ./
-COPY ./.eslint* ./
-COPY ./jest.config.js ./
 
-# Install dependencies and run build
+# Copy package*.json files first in order to make best use of docker layer caching
+COPY ./package*.json ./
+
+# npm clean slate install to get reproducible builds and quicker installs
 RUN npm ci
+
+# copy rest of the files
+COPY ./tsconfig.json ./
+COPY ./.eslintrc ./
+COPY ./jest.config.js ./
+COPY ./src ./src
+
+# build and test
 RUN npm run lint-ci
 RUN npm run transpile
 RUN npm run test

--- a/notification/src/api/rest/notificationExecutionEndpoint.ts
+++ b/notification/src/api/rest/notificationExecutionEndpoint.ts
@@ -13,12 +13,11 @@ export class NotificationExecutionEndpoint {
   }
 
   triggerNotification = async (req: express.Request, res: express.Response): Promise<void> => {
-    const triggerEvent = req.body as TransformationEvent
-    if (!this.triggerEventHandler.isValidTransformationEvent(triggerEvent)) {
+    if (!this.triggerEventHandler.isValidTransformationEvent(req.body)) {
       res.status(400).send('Malformed notification trigger request.')
       return
     }
-
+    const triggerEvent: TransformationEvent = req.body
     await this.triggerEventHandler.handleEvent(triggerEvent)
     res.status(200).send(`Successfully sent all notifications for pipeline ${triggerEvent.pipelineId}`)
   }

--- a/notification/src/api/triggerEventHandler.ts
+++ b/notification/src/api/triggerEventHandler.ts
@@ -2,7 +2,7 @@ import { TransformationEvent } from './transformationEvent'
 import * as NotificationMessageFactory from './notificationMessageFactory'
 import { NotificationRepository } from '../notification-config/notificationRepository'
 import NotificationExecutor from '../notification-execution/notificationExecutor'
-import { CONFIG_TYPE } from '../notification-config/notificationConfig'
+import { hasProperty, isObject } from '../validators'
 
 const NOTIFICATION_DATA_LOCATION_URL = process.env.NOTIFICATION_DATA_LOCATION_URL || 'localhost:9000/storage'
 
@@ -22,8 +22,7 @@ export class TriggerEventHandler {
    * @returns true on success, else false
    */
   public async handleEvent (transformationEvent: TransformationEvent): Promise<void> {
-    const isValid = this.isValidTransformationEvent(transformationEvent)
-    if (!isValid) {
+    if (!this.isValidTransformationEvent(transformationEvent)) {
       return Promise.reject(new Error('Trigger event is not valid'))
     }
 
@@ -35,21 +34,15 @@ export class TriggerEventHandler {
 
     const notificationJobs: Promise<void>[] = []
     for (const webhookConfig of configs.webhook) {
-      notificationJobs.push(
-        this.notificationExecutor.handleNotification(webhookConfig, CONFIG_TYPE.WEBHOOK, dataLocation, message, data)
-      )
+      notificationJobs.push(this.notificationExecutor.handleWebhook(webhookConfig, dataLocation, message, data))
     }
 
     for (const slackConfig of configs.slack) {
-      notificationJobs.push(
-        this.notificationExecutor.handleNotification(slackConfig, CONFIG_TYPE.SLACK, dataLocation, message, data)
-      )
+      notificationJobs.push(this.notificationExecutor.handleSlack(slackConfig, dataLocation, message, data))
     }
 
     for (const firebaseConfig of configs.firebase) {
-      notificationJobs.push(
-        this.notificationExecutor.handleNotification(firebaseConfig, CONFIG_TYPE.FCM, dataLocation, message, data)
-      )
+      notificationJobs.push(this.notificationExecutor.handleFCM(firebaseConfig, dataLocation, message, data))
     }
 
     await Promise.all(notificationJobs)
@@ -62,7 +55,10 @@ export class TriggerEventHandler {
       *
       * @returns     true, if param event is a TransformationEvent, else false
       */
-  public isValidTransformationEvent (event: TransformationEvent): boolean {
-    return !!event.pipelineId && !!event.pipelineName && (!!event.data || !!event.error)
+  public isValidTransformationEvent (event: unknown): event is TransformationEvent {
+    return isObject(event) &&
+      hasProperty(event, 'pipelineId') &&
+      hasProperty(event, 'pipelineName') &&
+      (hasProperty(event, 'data') || hasProperty(event, 'error'))
   }
 }

--- a/notification/src/env.ts
+++ b/notification/src/env.ts
@@ -1,4 +1,4 @@
-const isEmpty = (value: string | undefined): boolean => !value || value === ''
+const isEmpty = (value: string | undefined): value is undefined => !value || value === ''
 
 const getEnv = (envName: string): string => {
   const env = process.env[envName]
@@ -9,7 +9,7 @@ const getEnv = (envName: string): string => {
   }
 
   console.log(`[Environment Variable] ${envName} = ${env}`)
-  return env as string
+  return env
 }
 
 export const CONNECTION_RETRIES = +getEnv('CONNECTION_RETRIES')

--- a/notification/src/notification-config/notificationConfig.ts
+++ b/notification/src/notification-config/notificationConfig.ts
@@ -14,10 +14,6 @@ export class NotificationConfig {
   condition!: string;
 }
 
-export class NotificationConfigRequest extends NotificationConfig {
-  type!: CONFIG_TYPE
-}
-
 @Entity()
 export class SlackConfig extends NotificationConfig {
   @PrimaryGeneratedColumn()

--- a/notification/src/notification-execution/condition-evaluation/vm2SandboxExecutor.ts
+++ b/notification/src/notification-execution/condition-evaluation/vm2SandboxExecutor.ts
@@ -21,7 +21,7 @@ export default class VM2SandboxExecutor implements SandboxExecutor {
         JSON.stringify(data) +
       ');'
 
-    let result = false
+    let result: unknown
     try {
       result = this.vm.run(wrapper)
     } catch (err) {

--- a/notification/src/notification-execution/notificationExecutor.test.ts
+++ b/notification/src/notification-execution/notificationExecutor.test.ts
@@ -2,7 +2,7 @@
 import axios from 'axios'
 
 import VM2SandboxExecutor from './condition-evaluation/vm2SandboxExecutor'
-import { WebhookConfig, CONFIG_TYPE, SlackConfig } from '../notification-config/notificationConfig'
+import { WebhookConfig, SlackConfig } from '../notification-config/notificationConfig'
 import NotificationExecutor from './notificationExecutor'
 import SlackCallback from '@/notification-execution/notificationCallbacks/slackCallback'
 
@@ -10,6 +10,8 @@ jest.mock('axios')
 
 describe('JSNotificationService', () => {
   describe('notification system', () => {
+    // Type assertion is ok here, because we have mocked the whole axios module
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const post = axios.post as jest.Mock
 
     let notificationService: NotificationExecutor
@@ -42,13 +44,7 @@ describe('JSNotificationService', () => {
 
       const message = 'message'
       const dataLocation = 'location'
-      await notificationService.handleNotification(
-        notificationConfig,
-        CONFIG_TYPE.WEBHOOK,
-        dataLocation,
-        message,
-        undefined
-      )
+      await notificationService.handleWebhook(notificationConfig, dataLocation, message, undefined)
 
       expect(post).toHaveBeenCalledTimes(1)
       // check arguments for axios post
@@ -69,13 +65,7 @@ describe('JSNotificationService', () => {
 
       const message = 'message'
       const dataLocation = 'location'
-      await notificationService.handleNotification(
-        notificationConfig,
-        CONFIG_TYPE.WEBHOOK,
-        dataLocation,
-        message,
-        undefined
-      )
+      await notificationService.handleWebhook(notificationConfig, dataLocation, message, undefined)
 
       expect(post).toHaveBeenCalledTimes(1)
       // check arguments for axios post
@@ -96,7 +86,7 @@ describe('JSNotificationService', () => {
 
       const message = 'message'
       const dataLocation = 'location'
-      await notificationService.handleNotification(notificationConfig, CONFIG_TYPE.WEBHOOK, dataLocation, message, data)
+      await notificationService.handleWebhook(notificationConfig, dataLocation, message, data)
 
       expect(post).toHaveBeenCalledTimes(1)
       // check arguments for axios post
@@ -116,13 +106,7 @@ describe('JSNotificationService', () => {
       try {
         const message = 'message'
         const dataLocation = 'location'
-        await notificationService.handleNotification(
-          notificationConfig,
-          CONFIG_TYPE.WEBHOOK,
-          dataLocation,
-          message,
-          data
-        )
+        await notificationService.handleWebhook(notificationConfig, dataLocation, message, data)
         throw new Error('Fail test')
       } catch (err) {
         expect(err.message).toEqual(
@@ -146,7 +130,7 @@ describe('JSNotificationService', () => {
 
       const message = 'message'
       const dataLocation = 'location'
-      await notificationService.handleNotification(request, CONFIG_TYPE.SLACK, dataLocation, message, data)
+      await notificationService.handleSlack(request, dataLocation, message, data)
 
       const expectedObject: SlackCallback = {
         text: message

--- a/notification/src/notification-execution/notificationExecutor.ts
+++ b/notification/src/notification-execution/notificationExecutor.ts
@@ -2,11 +2,9 @@ import axios from 'axios'
 import * as firebase from 'firebase-admin'
 
 import {
-  CONFIG_TYPE,
-  NotificationConfig,
-  WebhookConfig,
+  FirebaseConfig,
   SlackConfig,
-  FirebaseConfig
+  WebhookConfig
 } from '../notification-config/notificationConfig'
 
 import SlackCallback from './notificationCallbacks/slackCallback'
@@ -29,37 +27,14 @@ export default class NotificationExecutor {
     return VERSION
   }
 
-  async handleNotification (
-    notification: NotificationConfig,
-    type: CONFIG_TYPE,
-    dataLocation: string,
-    message: string,
-    data?: object
-  ): Promise<void> {
-    console.log(`NotificationRequest received for pipeline: ${notification.pipelineId}.`)
-
-    const conditionHolds = this.executor.evaluate(notification.condition, data)
+  async handleWebhook (webhook: WebhookConfig, dataLocation: string, message: string, data?: object): Promise<void> {
+    console.log(`WebhookNotificationRequest received for pipeline: ${webhook.pipelineId}.`)
+    const conditionHolds = this.executor.evaluate(webhook.condition, data)
     console.log('Condition is ' + conditionHolds)
     if (!conditionHolds) { // no need to trigger notification
       return Promise.resolve()
     }
 
-    switch (type) {
-      case CONFIG_TYPE.WEBHOOK:
-        await this.handleWebhook(notification as WebhookConfig, dataLocation, message)
-        break
-      case CONFIG_TYPE.FCM:
-        await this.handleFCM(notification as FirebaseConfig, dataLocation, message)
-        break
-      case CONFIG_TYPE.SLACK:
-        await this.handleSlack(notification as SlackConfig, dataLocation, message)
-        break
-      default:
-        throw new Error('Notification type not implemented.')
-    }
-  }
-
-  private async handleWebhook (webhook: WebhookConfig, dataLocation: string, message: string): Promise<void> {
     const callbackObject: WebhookCallback = {
       location: dataLocation,
       message: message,
@@ -69,7 +44,14 @@ export default class NotificationExecutor {
     await axios.post(webhook.url, callbackObject)
   }
 
-  private async handleSlack (slack: SlackConfig, dataLocation: string, message: string): Promise<void> {
+  async handleSlack (slack: SlackConfig, dataLocation: string, message: string, data?: object): Promise<void> {
+    console.log(`SlackNotificationRequest received for pipeline: ${slack.pipelineId}.`)
+    const conditionHolds = this.executor.evaluate(slack.condition, data)
+    console.log('Condition is ' + conditionHolds)
+    if (!conditionHolds) { // no need to trigger notification
+      return Promise.resolve()
+    }
+
     let slackBaseUri = 'https://hooks.slack.com/services'
     if (process.env.MOCK_RECEIVER_HOST && process.env.MOCK_RECEIVER_PORT) {
       slackBaseUri = `http://${process.env.MOCK_RECEIVER_HOST}:${process.env.MOCK_RECEIVER_PORT}/slack`
@@ -82,20 +64,28 @@ export default class NotificationExecutor {
     await axios.post(url, callbackObject)
   }
 
-  private async handleFCM (firebaseRequest: FirebaseConfig, dataLocation: string, message: string): Promise<void> {
+  async handleFCM
+  (firebaseConfig: FirebaseConfig, dataLocation: string, message: string, data?: object): Promise<void> {
+    console.log(`FirebaseNotificationRequest received for pipeline: ${firebaseConfig.pipelineId}.`)
+    const conditionHolds = this.executor.evaluate(firebaseConfig.condition, data)
+    console.log('Condition is ' + conditionHolds)
+    if (!conditionHolds) { // no need to trigger notification
+      return Promise.resolve()
+    }
+
     let app: App
     try {
-      app = firebase.app(firebaseRequest.clientEmail)
+      app = firebase.app(firebaseConfig.clientEmail)
     } catch (e) { // app does not exist yet
       app = firebase.initializeApp({
         credential: firebase.credential.cert({
-          projectId: firebaseRequest.projectId,
-          clientEmail: firebaseRequest.clientEmail,
-          privateKey: firebaseRequest.privateKey.replace(/\\n/g, '\n')
+          projectId: firebaseConfig.projectId,
+          clientEmail: firebaseConfig.clientEmail,
+          privateKey: firebaseConfig.privateKey.replace(/\\n/g, '\n')
         }),
-        databaseURL: `https://${firebaseRequest.projectId}.firebaseio.com`
+        databaseURL: `https://${firebaseConfig.projectId}.firebaseio.com`
       },
-      firebaseRequest.clientEmail)
+      firebaseConfig.clientEmail)
     }
     const firebaseMessage: FcmCallback = {
       notification: {
@@ -105,7 +95,7 @@ export default class NotificationExecutor {
       data: {
         message: message
       },
-      topic: firebaseRequest.topic
+      topic: firebaseConfig.topic
     }
     console.log(`Sending firebase message, callback object: ${JSON.stringify(firebaseMessage)}.`)
     const firebaseResponse = await firebase.messaging(app).send(firebaseMessage)

--- a/notification/src/validators.ts
+++ b/notification/src/validators.ts
@@ -1,0 +1,18 @@
+export function isNumber (x: unknown): x is number {
+  return typeof x === 'number'
+}
+
+export function isString (x: unknown): x is string {
+  return typeof x === 'string'
+}
+
+export function isObject (x: unknown): x is object {
+  return typeof x === 'object'
+}
+
+// Helper function to fix issue that `in` operator as type guard is not widening type with the asserted property key
+// See https://github.com/microsoft/TypeScript/issues/21732
+export function hasProperty<P extends PropertyKey, O extends object> (object: O, name: P):
+  object is O & { [K in P]: unknown } {
+  return name in object
+}


### PR DESCRIPTION
- Remove usage of `as` operator (see #171)
- Refactor REST API endpoint validation to use type guards.
- Refactor `Dockerfile` to better use layer caching