### PR TITLE
Scheduler: Remove usage of `as` operator

### DIFF
--- a/scheduler/.eslintrc
+++ b/scheduler/.eslintrc
@@ -20,6 +20,7 @@
     "@typescript-eslint/no-use-before-define": ["warn", { "functions": false, "classes": true }],
     "max-len": [2, 120, 4, { "ignoreUrls": true }],
     "@typescript-eslint/explicit-function-return-type": [1, { "allowExpressions": true }],
-    "@typescript-eslint/no-floating-promises": "warn"
+    "@typescript-eslint/no-floating-promises": "warn",
+    "@typescript-eslint/consistent-type-assertions": [ "warn", { "assertionStyle": "never" }]
   }
 }

--- a/scheduler/src/env.ts
+++ b/scheduler/src/env.ts
@@ -1,4 +1,4 @@
-const isEmpty = (value: string | undefined): boolean => !value || value === ''
+const isEmpty = (value: string | undefined): value is undefined => !value || value === ''
 
 const getEnv = (envName: string): string => {
   const env = process.env[envName]
@@ -9,7 +9,7 @@ const getEnv = (envName: string): string => {
   }
 
   console.log(`[Environment Variable] ${envName} = ${env}`)
-  return env as string
+  return env
 }
 
 export const MAX_TRIGGER_RETRIES = +getEnv('MAX_TRIGGER_RETRIES')

--- a/scheduler/src/index.ts
+++ b/scheduler/src/index.ts
@@ -7,8 +7,7 @@ import * as Scheduling from './scheduling'
 import {
   CONNECTION_RETRIES,
   CONNECTION_BACKOFF_IN_MS
-}
-  from './env'
+} from './env'
 
 const app = express()
 const port = 8080

--- a/scheduler/src/scheduling.test.ts
+++ b/scheduler/src/scheduling.test.ts
@@ -10,11 +10,14 @@ import { EventType } from './interfaces/datasource-event'
 import DatasourceConfig from './interfaces/datasource-config'
 
 jest.mock('./clients/adapter-client')
+// Type assertion is ok here, because we have mocked the whole './clients/adapter-client' module
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
 const mockedGetLatestEventId = getLatestEventId as jest.Mock
 mockedGetLatestEventId.mockResolvedValue(321)
 const mockedGetAllDatasources = getAllDatasources as jest.Mock
 const mockedGetEventsAfter = getEventsAfter as jest.Mock
 const mockedGetDatasource = getDatasource as jest.Mock
+/* eslint-enable @typescript-eslint/consistent-type-assertions */
 
 jest.mock('./env', () => () => ({
   MAX_TRIGGER_RETRIES: 2


### PR DESCRIPTION
See #171