### PR TITLE
Add location in typescript file to stack traces

### DIFF
--- a/notification/package.json
+++ b/notification/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "scripts": {
         "start": "npm run transpile && npm run start:transpiled",
-        "start:transpiled": "node dist/index.js",
+        "start:transpiled": "node --enable-source-maps dist/index.js",
         "transpile": "tsc",
         "lint": "./node_modules/.bin/eslint src --ext .ts,.js --fix",
         "lint-ci": "./node_modules/.bin/eslint src --ext .ts,.js --max-warnings=0",

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "npm run transpile && npm run start:transpiled",
-    "start:transpiled": "node --max-http-header-size 10000000 dist/index.js",
+    "start:transpiled": "node --enable-source-maps --max-http-header-size 10000000 dist/index.js",
     "transpile": "tsc",
     "lint": "./node_modules/.bin/eslint src --ext .ts,.js --fix",
     "lint-ci": "./node_modules/.bin/eslint src --ext .ts,.js --max-warnings=0",

--- a/storage/storage-mq/package.json
+++ b/storage/storage-mq/package.json
@@ -5,7 +5,7 @@
     "main": "dis/index.js",
     "scripts": {
         "start": "npm run transpile && npm run start:transpiled",
-        "start:transpiled": "node --max-http-header-size 10000000 dist/index.js",
+        "start:transpiled": "node --enable-source-maps --max-http-header-size 10000000 dist/index.js",
         "transpile": "tsc",
         "lint": "./node_modules/.bin/eslint src --ext .ts,.js --fix",
         "lint-ci": "./node_modules/.bin/eslint src --ext .ts,.js --max-warnings=0",

--- a/transformation/package.json
+++ b/transformation/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "npm run transpile && npm run start:transpiled",
-    "start:transpiled": "node dist/index.js",
+    "start:transpiled": "node --enable-source-maps dist/index.js",
     "transpile": "tsc",
     "lint": "./node_modules/.bin/eslint src --ext .ts,.js --fix",
     "lint-ci": "./node_modules/.bin/eslint src --ext .ts,.js --max-warnings=0",


### PR DESCRIPTION
This PR adds support for using the source maps generated by typescript in the stack traces generated by NodeJS. This will simplify debugging and identifying where an error actually happened a lot.

This is how a stack trace is currently printed:
```
(node:18) UnhandledPromiseRejectionWarning: Error: Source maps test
    at Server.<anonymous> (/app/dist/index.js:55:11)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

With this PR the stack trace will also contain the exact location of the error in the typescript file:
```
(node:17) UnhandledPromiseRejectionWarning: Error: Source maps test
    at Server.<anonymous> (/app/dist/index.js:55:11)
        -> /app/src/index.ts:68:9
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```