### PR TITLE
Align more typescript-eslint rules with standard

### DIFF
--- a/notification/.eslintrc
+++ b/notification/.eslintrc
@@ -34,6 +34,16 @@
         // This issue is not really effecting us and we use `object` heavily, therefore `object` is allowed.
         "object": false
       }
-    }]
+    }],
+    "@typescript-eslint/member-delimiter-style": [
+      "error",
+      {
+        "multiline": { "delimiter": "none" },
+        "singleline": { "delimiter": "comma", "requireLast": false }
+      }
+    ],
+    "semi": "off",
+    "@typescript-eslint/semi": ["error", "never"],
+    "@typescript-eslint/method-signature-style": "error"
   }
 }

--- a/notification/src/api/rest/notificationRequest.ts
+++ b/notification/src/api/rest/notificationRequest.ts
@@ -1,25 +1,25 @@
 export interface NotificationRequest {
-  pipelineId: number;
-  pipelineName: string;
-  data: object;
-  dataLocation: string;
-  condition: string;
-  type: string;
+  pipelineId: number
+  pipelineName: string
+  data: object
+  dataLocation: string
+  condition: string
+  type: string
 }
 
 export interface Webhook extends NotificationRequest {
-  url: string;
+  url: string
 }
 
 export interface Slack extends NotificationRequest {
-  workspaceId: string;
-  channelId: string;
-  secret: string;
+  workspaceId: string
+  channelId: string
+  secret: string
 }
 
 export interface Firebase extends NotificationRequest {
-  projectId: string;
-  clientEmail: string;
-  privateKey: string;
-  topic: string;
+  projectId: string
+  clientEmail: string
+  privateKey: string
+  topic: string
 }

--- a/notification/src/api/transformationEvent.ts
+++ b/notification/src/api/transformationEvent.ts
@@ -3,9 +3,9 @@
  * Event sent by the transformation service upon transformation finish
  */
 export interface TransformationEvent {
-  pipelineId: number;
-  pipelineName: string;
+  pipelineId: number
+  pipelineName: string
 
-  data?: object;
-  error?: object;
+  data?: object
+  error?: object
 }

--- a/notification/src/notification-config/notificationConfig.ts
+++ b/notification/src/notification-config/notificationConfig.ts
@@ -8,10 +8,10 @@ export enum CONFIG_TYPE{
 
 export class NotificationConfig {
   @Column()
-  pipelineId!: number;
+  pipelineId!: number
 
   @Column()
-  condition!: string;
+  condition!: string
 }
 
 @Entity()
@@ -20,13 +20,13 @@ export class SlackConfig extends NotificationConfig {
   id!: number
 
   @Column()
-  workspaceId!: string;
+  workspaceId!: string
 
   @Column()
-  channelId!: string;
+  channelId!: string
 
   @Column()
-  secret!: string;
+  secret!: string
 }
 
 @Entity()
@@ -35,7 +35,7 @@ export class WebhookConfig extends NotificationConfig {
   id!: number
 
   @Column()
-  url!: string;
+  url!: string
 }
 
 @Entity()
@@ -44,14 +44,14 @@ export class FirebaseConfig extends NotificationConfig {
   id!: number
 
   @Column()
-  projectId!: string;
+  projectId!: string
 
   @Column()
-  clientEmail!: string;
+  clientEmail!: string
 
   @Column()
-  privateKey!: string;
+  privateKey!: string
 
   @Column()
-  topic!: string;
+  topic!: string
 }

--- a/notification/src/notification-config/notificationRepository.ts
+++ b/notification/src/notification-config/notificationRepository.ts
@@ -2,23 +2,23 @@ import { NotificationSummary } from './notificationSummary'
 import { FirebaseConfig, SlackConfig, WebhookConfig } from './notificationConfig'
 
 export interface NotificationRepository {
-  init(retries: number, backoff: number): void;
-  getConfigsForPipeline(pipelineId: number): Promise<NotificationSummary>;
-  deleteConfigsForPipelineID(pipelineId: number): void;
+  init: (retries: number, backoff: number) => void
+  getConfigsForPipeline: (pipelineId: number) => Promise<NotificationSummary>
+  deleteConfigsForPipelineID: (pipelineId: number) => void
 
-  getSlackConfig(id: number): Promise<SlackConfig>;
-  getWebhookConfig(id: number): Promise<WebhookConfig>;
-  getFirebaseConfig(id: number): Promise<FirebaseConfig>;
+  getSlackConfig: (id: number) => Promise<SlackConfig>
+  getWebhookConfig: (id: number) => Promise<WebhookConfig>
+  getFirebaseConfig: (id: number) => Promise<FirebaseConfig>
 
-  saveWebhookConfig(webhookConfig: WebhookConfig): Promise<WebhookConfig>;
-  saveSlackConfig(slackConfig: SlackConfig): Promise<SlackConfig>;
-  saveFirebaseConfig(firebaseConfig: FirebaseConfig): Promise<FirebaseConfig>;
+  saveWebhookConfig: (webhookConfig: WebhookConfig) => Promise<WebhookConfig>
+  saveSlackConfig: (slackConfig: SlackConfig) => Promise<SlackConfig>
+  saveFirebaseConfig: (firebaseConfig: FirebaseConfig) => Promise<FirebaseConfig>
 
-  updateSlackConfig(id: number, slackConfig: SlackConfig): Promise<SlackConfig>;
-  updateWebhookConfig(id: number, webhookConfig: WebhookConfig): Promise<WebhookConfig>;
-  updateFirebaseConfig(id: number, firebaseConfig: FirebaseConfig): Promise<FirebaseConfig>;
+  updateSlackConfig: (id: number, slackConfig: SlackConfig) => Promise<SlackConfig>
+  updateWebhookConfig: (id: number, webhookConfig: WebhookConfig) => Promise<WebhookConfig>
+  updateFirebaseConfig: (id: number, firebaseConfig: FirebaseConfig) => Promise<FirebaseConfig>
 
-  deleteSlackConfig(id: number): Promise<void>;
-  deleteWebhookConfig(id: number): Promise<void>;
-  deleteFirebaseConfig(id: number): Promise<void>;
+  deleteSlackConfig: (id: number) => Promise<void>
+  deleteWebhookConfig: (id: number) => Promise<void>
+  deleteFirebaseConfig: (id: number) => Promise<void>
 }

--- a/notification/src/notification-config/notificationSummary.ts
+++ b/notification/src/notification-config/notificationSummary.ts
@@ -10,10 +10,10 @@ import { WebhookConfig, SlackConfig, FirebaseConfig } from './notificationConfig
  */
 export interface NotificationSummary {
 
-  webhook: WebhookConfig[];
+  webhook: WebhookConfig[]
 
-  slack: SlackConfig[];
+  slack: SlackConfig[]
 
-  firebase: FirebaseConfig[];
+  firebase: FirebaseConfig[]
 
 }

--- a/notification/src/notification-execution/condition-evaluation/sandboxExecutor.ts
+++ b/notification/src/notification-execution/condition-evaluation/sandboxExecutor.ts
@@ -1,3 +1,3 @@
 export default interface SandboxExecutor {
-  evaluate(expression: string, data?: object): boolean;
+  evaluate: (expression: string, data?: object) => boolean
 }

--- a/notification/src/notification-execution/condition-evaluation/vm2SandboxExecutor.ts
+++ b/notification/src/notification-execution/condition-evaluation/vm2SandboxExecutor.ts
@@ -3,7 +3,7 @@ import { VM } from 'vm2'
 import SandboxExecutor from './sandboxExecutor'
 
 export default class VM2SandboxExecutor implements SandboxExecutor {
-  vm: VM;
+  vm: VM
 
   constructor (timeout = 5000) {
     this.vm = new VM({
@@ -11,7 +11,7 @@ export default class VM2SandboxExecutor implements SandboxExecutor {
     })
   }
 
-  evaluate (expression: string, data: object): boolean {
+  evaluate (expression: string, data?: object): boolean {
     console.log(`Evaluating expression: "${expression}" on data`)
     const wrapper =
       'f=function(data){' +

--- a/notification/src/notification-execution/notificationCallbacks/fcmCallback.ts
+++ b/notification/src/notification-execution/notificationCallbacks/fcmCallback.ts
@@ -1,8 +1,8 @@
 export default interface FcmCallback {
   notification: {
-    title: string;
-    body: string;
-  };
-  data?: {[key: string]: string};
-  topic: string;
+    title: string
+    body: string
+  }
+  data?: {[key: string]: string}
+  topic: string
 }

--- a/notification/src/notification-execution/notificationCallbacks/slackCallback.ts
+++ b/notification/src/notification-execution/notificationCallbacks/slackCallback.ts
@@ -1,3 +1,3 @@
 export default interface SlackCallback {
-  text: string;
+  text: string
 }

--- a/notification/src/notification-execution/notificationCallbacks/webhookCallback.ts
+++ b/notification/src/notification-execution/notificationCallbacks/webhookCallback.ts
@@ -1,5 +1,5 @@
 export default interface WebhookCallback {
-  location: string;
-  message: string;
-  timestamp: Date;
+  location: string
+  message: string
+  timestamp: Date
 }

--- a/notification/src/notification-execution/notificationExecutor.ts
+++ b/notification/src/notification-execution/notificationExecutor.ts
@@ -12,7 +12,7 @@ import WebhookCallback from './notificationCallbacks/webhookCallback'
 import FcmCallback from './notificationCallbacks/fcmCallback'
 
 import SandboxExecutor from './condition-evaluation/sandboxExecutor'
-import App = firebase.app.App;
+import App = firebase.app.App
 
 const VERSION = '0.0.1'
 

--- a/scheduler/.eslintrc
+++ b/scheduler/.eslintrc
@@ -34,6 +34,16 @@
         // This issue is not really effecting us and we use `object` heavily, therefore `object` is allowed.
         "object": false
       }
-    }]
+    }],
+    "@typescript-eslint/member-delimiter-style": [
+      "error",
+      {
+        "multiline": { "delimiter": "none" },
+        "singleline": { "delimiter": "comma", "requireLast": false }
+      }
+    ],
+    "semi": "off",
+    "@typescript-eslint/semi": ["error", "never"],
+    "@typescript-eslint/method-signature-style": "error"
   }
 }

--- a/scheduler/src/interfaces/datasource-config.ts
+++ b/scheduler/src/interfaces/datasource-config.ts
@@ -1,20 +1,20 @@
 export default interface DatasourceConfig {
-  id: number;
-  protocol: DatasourceProtocol;
-  format: object;
-  trigger: DatasourceTrigger;
-  metadata: object;
+  id: number
+  protocol: DatasourceProtocol
+  format: object
+  trigger: DatasourceTrigger
+  metadata: object
 }
 
 export interface DatasourceProtocol {
-  type: string;
+  type: string
   parameters: {
-    location?: string;
-  };
+    location?: string
+  }
 }
 
 export interface DatasourceTrigger {
-  periodic: boolean;
-  firstExecution: Date;
-  interval: number;
+  periodic: boolean
+  firstExecution: Date
+  interval: number
 }

--- a/scheduler/src/interfaces/datasource-event.ts
+++ b/scheduler/src/interfaces/datasource-event.ts
@@ -1,7 +1,7 @@
 export default interface DatasourceEvent {
-  eventId: number;
-  datasourceId: number;
-  eventType: EventType;
+  eventId: number
+  datasourceId: number
+  eventType: EventType
 }
 
 export enum EventType {

--- a/scheduler/src/interfaces/scheduling-job.ts
+++ b/scheduler/src/interfaces/scheduling-job.ts
@@ -2,6 +2,6 @@ import schedule from 'node-schedule'
 import DatasourceConfig from './datasource-config'
 
 export default interface SchedulingJob {
-  scheduleJob: schedule.Job;
-  datasourceConfig: DatasourceConfig;
+  scheduleJob: schedule.Job
+  datasourceConfig: DatasourceConfig
 }

--- a/storage/storage-mq/.eslintrc
+++ b/storage/storage-mq/.eslintrc
@@ -34,6 +34,16 @@
         // This issue is not really effecting us and we use `object` heavily, therefore `object` is allowed.
         "object": false
       }
-    }]
+    }],
+    "@typescript-eslint/member-delimiter-style": [
+      "error",
+      {
+        "multiline": { "delimiter": "none" },
+        "singleline": { "delimiter": "comma", "requireLast": false }
+      }
+    ],
+    "semi": "off",
+    "@typescript-eslint/semi": ["error", "never"],
+    "@typescript-eslint/method-signature-style": "error"
   }
 }

--- a/storage/storage-mq/src/api/pipelineConfigEventHandler.ts
+++ b/storage/storage-mq/src/api/pipelineConfigEventHandler.ts
@@ -17,9 +17,9 @@ export default class PipelineConfigEventHandler {
 }
 
 export interface PipelineCreatedEvent {
-  pipelineId: string;
+  pipelineId: string
 }
 
 export interface PipelineDeletedEvent {
-  pipelineId: string;
+  pipelineId: string
 }

--- a/storage/storage-mq/src/api/pipelineExecutionEventHandler.ts
+++ b/storage/storage-mq/src/api/pipelineExecutionEventHandler.ts
@@ -18,7 +18,7 @@ export default class PipelineExecutionEventHandler {
 }
 
 export interface PipelineExecutedEvent {
-  pipelineId: string;
-  timestamp: Date;
-  data: object;
+  pipelineId: string
+  timestamp: Date
+  data: object
 }

--- a/storage/storage-mq/src/storage-content/storageContent.ts
+++ b/storage/storage-mq/src/storage-content/storageContent.ts
@@ -1,6 +1,6 @@
 export interface StorageContent {
-  id?: number;
-  pipelineId: string;
-  timestamp: Date;
-  data: object;
+  id?: number
+  pipelineId: string
+  timestamp: Date
+  data: object
 }

--- a/storage/storage-mq/src/storage-content/storageContentRepository.ts
+++ b/storage/storage-mq/src/storage-content/storageContentRepository.ts
@@ -1,9 +1,9 @@
 import { StorageContent } from './storageContent'
 
 export interface StorageContentRepository {
-  init(retries: number, backoff: number): Promise<void>;
+  init: (retries: number, backoff: number) => Promise<void>
 
-  getAllContent(tableIdentifier: string): Promise<StorageContent[] | undefined>;
-  getContent(tableIdentifier: string, contentId: string): Promise<StorageContent | undefined>;
-  saveContent(tableIdentifier: string, content: StorageContent): Promise<number>;
+  getAllContent: (tableIdentifier: string) => Promise<StorageContent[] | undefined>
+  getContent: (tableIdentifier: string, contentId: string) => Promise<StorageContent | undefined>
+  saveContent: (tableIdentifier: string, content: StorageContent) => Promise<number>
 }

--- a/storage/storage-mq/src/storage-structure/storageStructureRepository.ts
+++ b/storage/storage-mq/src/storage-structure/storageStructureRepository.ts
@@ -1,7 +1,7 @@
 
 export interface StorageStructureRepository {
-  init(retries: number, backoff: number): Promise<void>;
+  init: (retries: number, backoff: number) => Promise<void>
 
-  create(tableIdentifier: string): Promise<void>;
-  delete(tableIdentifier: string): Promise<void>;
+  create: (tableIdentifier: string) => Promise<void>
+  delete: (tableIdentifier: string) => Promise<void>
 }

--- a/transformation/.eslintrc
+++ b/transformation/.eslintrc
@@ -34,6 +34,16 @@
         // This issue is not really effecting us and we use `object` heavily, therefore `object` is allowed.
         "object": false
       }
-    }]
+    }],
+    "@typescript-eslint/member-delimiter-style": [
+      "error",
+      {
+        "multiline": { "delimiter": "none" },
+        "singleline": { "delimiter": "comma", "requireLast": false }
+      }
+    ],
+    "semi": "off",
+    "@typescript-eslint/semi": ["error", "never"],
+    "@typescript-eslint/method-signature-style": "error"
   }
 }

--- a/transformation/src/api/pipelineConfigTriggerRequest.ts
+++ b/transformation/src/api/pipelineConfigTriggerRequest.ts
@@ -1,8 +1,8 @@
 import { isObject, isNumber, isString, hasProperty } from '../validators'
 
 export interface PipelineConfigTriggerRequest {
-  datasourceId: number;
-  data: string;
+  datasourceId: number
+  data: string
 }
 
 export class PipelineConfigTriggerRequestValidator {

--- a/transformation/src/api/pipelineExecutionRequest.ts
+++ b/transformation/src/api/pipelineExecutionRequest.ts
@@ -1,8 +1,8 @@
 import { hasProperty, isObject, isString } from '../validators'
 
 export interface PipelineExecutionRequest {
-  func: string;
-  data: object;
+  func: string
+  data: object
 }
 
 export class PipelineExecutionRequestValidator {

--- a/transformation/src/pipeline-config/model/pipelineConfig.ts
+++ b/transformation/src/pipeline-config/model/pipelineConfig.ts
@@ -1,38 +1,38 @@
 import { isObject, isString, isNumber, hasProperty } from '../../validators'
 
 export interface PipelineConfig {
-  id: number;
-  datasourceId: number;
-  transformation: TransformationConfig;
-  metadata: Metadata;
+  id: number
+  datasourceId: number
+  transformation: TransformationConfig
+  metadata: Metadata
 }
 
 export interface TransformationConfig {
-  func: string;
+  func: string
 }
 
 export interface Metadata {
-  author: string;
-  displayName: string;
-  license: string;
-  description: string;
-  creationTimestamp: Date;
+  author: string
+  displayName: string
+  license: string
+  description: string
+  creationTimestamp: Date
 }
 
 /**
  * PipelineConfig data transfer object that clients must use when creating or updating a PipelineConfig
  */
 export interface PipelineConfigDTO {
-  datasourceId: number;
-  transformation: TransformationConfig;
-  metadata: MetadataDTO;
+  datasourceId: number
+  transformation: TransformationConfig
+  metadata: MetadataDTO
 }
 
 export interface MetadataDTO {
-  author: string;
-  displayName: string;
-  license: string;
-  description: string;
+  author: string
+  displayName: string
+  license: string
+  description: string
 }
 
 export class PipelineConfigDTOValidator {

--- a/transformation/src/pipeline-config/pipelineConfigManager.ts
+++ b/transformation/src/pipeline-config/pipelineConfigManager.ts
@@ -6,8 +6,8 @@ import ConfigWritesPublisher from './publisher/configWritesPublisher'
 
 export class PipelineConfigManager {
   private pipelineExecutor: PipelineExecutor
-  private pipelineConfigRepository: PipelineConfigRepository;
-  private configWritesPublisher: ConfigWritesPublisher;
+  private pipelineConfigRepository: PipelineConfigRepository
+  private configWritesPublisher: ConfigWritesPublisher
   private executionResultPublisher: ExecutionResultPublisher
 
   constructor (

--- a/transformation/src/pipeline-config/pipelineConfigRepository.ts
+++ b/transformation/src/pipeline-config/pipelineConfigRepository.ts
@@ -1,11 +1,11 @@
 import { PipelineConfig, PipelineConfigDTO } from './model/pipelineConfig'
 
 export default interface PipelineConfigRepository {
-  create(config: PipelineConfigDTO): Promise<PipelineConfig>;
-  get(id: number): Promise<PipelineConfig | undefined>;
-  getAll(): Promise<PipelineConfig[]>;
-  getByDatasourceId(datasourceId: number): Promise<PipelineConfig[]>;
-  update(id: number, config: PipelineConfigDTO): Promise<void>;
-  delete(id: number): Promise<PipelineConfig>;
-  deleteAll(): Promise<PipelineConfig[]>;
+  create: (config: PipelineConfigDTO) => Promise<PipelineConfig>
+  get: (id: number) => Promise<PipelineConfig | undefined>
+  getAll: () => Promise<PipelineConfig[]>
+  getByDatasourceId: (datasourceId: number) => Promise<PipelineConfig[]>
+  update: (id: number, config: PipelineConfigDTO) => Promise<void>
+  delete: (id: number) => Promise<PipelineConfig>
+  deleteAll: () => Promise<PipelineConfig[]>
 }

--- a/transformation/src/pipeline-config/postgresPipelineConfigRepository.ts
+++ b/transformation/src/pipeline-config/postgresPipelineConfigRepository.ts
@@ -40,14 +40,14 @@ const DELETE_ALL_STATEMENT = `
   DELETE FROM "${POSTGRES_SCHEMA}"."${POSTGRES_TABLE}" RETURNING *`
 
 interface DatabasePipeline {
-  id: string;
-  datasourceId: string;
-  func: string;
-  author: string;
-  displayName: string;
-  license: string;
-  description: string;
-  createdAt: Date;
+  id: string
+  datasourceId: string
+  func: string
+  author: string
+  displayName: string
+  license: string
+  description: string
+  createdAt: Date
 }
 
 export default class PostgresPipelineConfigRepository implements PipelineConfigRepository {

--- a/transformation/src/pipeline-config/publisher/configWritesPublisher.ts
+++ b/transformation/src/pipeline-config/publisher/configWritesPublisher.ts
@@ -1,5 +1,5 @@
 export default interface ConfigWritesPublisher {
-  publishCreation(pipelineId: number, pipelineName: string): boolean;
-  publishUpdate(pipelineId: number, pipelineName: string): boolean;
-  publishDeletion(pipelineId: number, pipelineName: string): boolean;
+  publishCreation: (pipelineId: number, pipelineName: string) => boolean
+  publishUpdate: (pipelineId: number, pipelineName: string) => boolean
+  publishDeletion: (pipelineId: number, pipelineName: string) => boolean
 }

--- a/transformation/src/pipeline-config/publisher/executionResultPublisher.ts
+++ b/transformation/src/pipeline-config/publisher/executionResultPublisher.ts
@@ -1,4 +1,4 @@
 export interface ExecutionResultPublisher {
-  publishError(pipelineId: number, pipelineName: string, error: string): boolean;
-  publishSuccess(pipelineId: number, pipelineName: string, result: object): boolean;
+  publishError: (pipelineId: number, pipelineName: string, error: string) => boolean
+  publishSuccess: (pipelineId: number, pipelineName: string, result: object) => boolean
 }

--- a/transformation/src/pipeline-execution/jobResult.ts
+++ b/transformation/src/pipeline-execution/jobResult.ts
@@ -2,7 +2,7 @@ import Stats from './stats'
 import JobError from './sandbox/jobError'
 
 export default interface JobResult {
-  data?: object;
-  error?: JobError;
-  stats: Stats;
+  data?: object
+  error?: JobError
+  stats: Stats
 }

--- a/transformation/src/pipeline-execution/sandbox/executionResult.ts
+++ b/transformation/src/pipeline-execution/sandbox/executionResult.ts
@@ -1,6 +1,6 @@
 import JobError from './jobError'
 
 export default interface ExecutionResult {
-  error?: JobError;
-  data?: object;
+  error?: JobError
+  data?: object
 }

--- a/transformation/src/pipeline-execution/sandbox/jobError.ts
+++ b/transformation/src/pipeline-execution/sandbox/jobError.ts
@@ -1,7 +1,7 @@
 export default interface JobError {
-  name: string;
-  message: string;
-  lineNumber: number;
-  position: number;
-  stacktrace: string[];
+  name: string
+  message: string
+  lineNumber: number
+  position: number
+  stacktrace: string[]
 }

--- a/transformation/src/pipeline-execution/sandbox/sandboxExecutor.ts
+++ b/transformation/src/pipeline-execution/sandbox/sandboxExecutor.ts
@@ -1,5 +1,5 @@
 import ExecutionResult from './executionResult'
 
 export default interface SandboxExecutor {
-  execute(code: string, data: object): ExecutionResult;
+  execute: (code: string, data: object) => ExecutionResult
 }

--- a/transformation/src/pipeline-execution/sandbox/vm2SandboxExecutor.ts
+++ b/transformation/src/pipeline-execution/sandbox/vm2SandboxExecutor.ts
@@ -7,7 +7,7 @@ import { convertRuntimeError, convertSyntaxError } from './vm2StacktraceParser'
 const FUNCTION_WRAP_PREFIX_LENGTH = 1
 
 export default class VM2SandboxExecutor implements SandboxExecutor {
-  vm: VM;
+  vm: VM
 
   constructor (timeout = 5000) {
     this.vm = new VM({

--- a/transformation/src/pipeline-execution/stats.ts
+++ b/transformation/src/pipeline-execution/stats.ts
@@ -1,5 +1,5 @@
 export default interface Stats {
-  durationInMilliSeconds: number;
-  startTimestamp: number;
-  endTimestamp: number;
+  durationInMilliSeconds: number
+  startTimestamp: number
+  endTimestamp: number
 }


### PR DESCRIPTION
- Prohibit and remove semicolon usage everywhere
- Apply `typescript-eslint/method-signature-style` rule

See #195
