### PR TITLE
Change workflow CI trigger to avoid double runs (closes #206)

### DIFF
--- a/.github/workflows/ods.yml
+++ b/.github/workflows/ods.yml
@@ -1,6 +1,13 @@
 name: Open Data Service (ODS)
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
With this PR the trigger for the CI run will be changed to avoid double runs of the workflow.
It will only trigger the CI if a commit is pushed into the master branch or the commit is part of a PR to the master branch.
Branches apart of that can also be checked with the manual workflow dispatch if necessary.
