### PR TITLE
UI: limit transformation preview data to max height and scroll overflow

### DIFF
--- a/ui/src/pipeline/edit/transformation/ResultView.vue
+++ b/ui/src/pipeline/edit/transformation/ResultView.vue
@@ -4,7 +4,7 @@
       <div v-if="result.data">
         <v-subheader>Transformed Data</v-subheader>
         <v-card-text class="text-left">
-          <pre>{{ result.data }}</pre>
+          <pre style="max-height: 400px; overflow:auto; text-align: left">{{ result.data }}</pre>
         </v-card-text>
       </div>
 
@@ -13,7 +13,7 @@
           Error
         </v-subheader>
         <v-card-text class="text-left">
-          <pre>{{ result.error }}</pre>
+          <pre style="max-height: 400px; overflow:auto; text-align: left">{{ result.error }}</pre>
         </v-card-text>
       </div>
 


### PR DESCRIPTION
Previously you had to scroll to the bottom of all data to further configure. Took a while with longer datasets. Limited to a max height now, and people can scroll through if they are interested.