### PR TITLE
Remove absolute imports with `@/...`

### DIFF
--- a/notification/tsconfig.json
+++ b/notification/tsconfig.json
@@ -1,27 +1,17 @@
 {
   "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
     "target": "es2018",
     "module": "commonjs",
     "strict": true,
-    "jsx": "preserve",
-    "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "allowJs": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*", "tests/*"]
-    },
     "lib": ["es2018"],
     "outDir": "dist"
   },
   "include": [
-    "src/**/*.ts",
-    "src/**/*.vue",
-    "tests/**/*.ts",
-  ],
-  "exclude": ["node_modules"]
+    "src/**/*.ts"
+  ]
 }

--- a/pipeline/jest.config.js
+++ b/pipeline/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-    roots: ['./src']
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['./src']
 }

--- a/pipeline/src/api/amqp/pipelineConfigConsumer.ts
+++ b/pipeline/src/api/amqp/pipelineConfigConsumer.ts
@@ -1,4 +1,5 @@
 import * as AMQP from 'amqplib'
+
 import { PipelineConfigManager } from '../../pipeline-config/pipelineConfigManager'
 import { PipelineConfigTriggerRequest } from '../pipelineConfigTriggerRequest'
 import {

--- a/pipeline/src/api/rest/pipelineConfigEndpoint.ts
+++ b/pipeline/src/api/rest/pipelineConfigEndpoint.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 
-import { PipelineConfigManager } from '@/pipeline-config/pipelineConfigManager'
+import { PipelineConfigManager } from '../../pipeline-config/pipelineConfigManager'
 import { PipelineConfigDTOValidator } from '../../pipeline-config/model/pipelineConfig'
 import { isString } from '../../validators'
 

--- a/pipeline/tsconfig.json
+++ b/pipeline/tsconfig.json
@@ -3,25 +3,15 @@
     "target": "es2018",
     "module": "commonjs",
     "strict": true,
-    "jsx": "preserve",
-    "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "allowJs": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
     "lib": ["es2018"],
     "outDir": "dist"
   },
   "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue",
-    "tests/**/*.ts",
-    "tests/**/*.tsx"
-  ],
-  "exclude": ["node_modules"]
+    "src/**/*.ts"
+  ]
 }

--- a/scheduler/jest.config.js
+++ b/scheduler/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ["./src"]
-};
+  roots: ['./src']
+}

--- a/scheduler/src/clients/adapter-client.ts
+++ b/scheduler/src/clients/adapter-client.ts
@@ -2,7 +2,6 @@ import axios from 'axios'
 
 import type DatasourceConfig from '../interfaces/datasource-config'
 import type { DatasourceEvent } from '../interfaces/datasource-event'
-
 import { ADAPTER_SERVICE_URL } from '../env'
 
 const http = axios.create({

--- a/scheduler/src/interfaces/scheduling-job.ts
+++ b/scheduler/src/interfaces/scheduling-job.ts
@@ -1,4 +1,5 @@
 import type schedule from 'node-schedule'
+
 import type DatasourceConfig from './datasource-config'
 
 export default interface SchedulingJob {

--- a/scheduler/tsconfig.json
+++ b/scheduler/tsconfig.json
@@ -3,22 +3,15 @@
     "target": "es2018",
     "module": "commonjs",
     "strict": true,
-    "jsx": "preserve",
-    "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "allowJs": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
-    "lib": ["es2018"],
+    "lib": ["es2020"],
     "outDir": "dist"
   },
   "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
-  "exclude": ["node_modules"]
+    "src/**/*.ts"
+  ]
 }

--- a/storage/storage-mq/jest.config.js
+++ b/storage/storage-mq/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ["./src"]
-};
+  roots: ['./src']
+}

--- a/storage/storage-mq/src/api/amqp/pipelineConfigConsumer.ts
+++ b/storage/storage-mq/src/api/amqp/pipelineConfigConsumer.ts
@@ -1,6 +1,6 @@
 import * as AMQP from 'amqplib'
+
 import AmqpConsumer from '../../util/amqpConsumer'
-import PipelineConfigEventHandler from '../pipelineConfigEventHandler'
 import {
   AMQP_URL,
   AMQP_PIPELINE_CONFIG_EXCHANGE,
@@ -9,6 +9,7 @@ import {
   AMQP_PIPELINE_CONFIG_CREATED_TOPIC,
   AMQP_PIPELINE_CONFIG_DELETED_TOPIC
 } from '../../env'
+import PipelineConfigEventHandler from '../pipelineConfigEventHandler'
 
 export class PipelineConfigConsumer {
   constructor (

--- a/storage/storage-mq/src/api/amqp/pipelineExecutionConsumer.ts
+++ b/storage/storage-mq/src/api/amqp/pipelineExecutionConsumer.ts
@@ -1,6 +1,6 @@
 import * as AMQP from 'amqplib'
+
 import AmqpConsumer from '../../util/amqpConsumer'
-import PipelineExecutionEventHandler from '../pipelineExecutionEventHandler'
 import {
   AMQP_URL,
   AMQP_PIPELINE_EXECUTION_EXCHANGE,
@@ -8,6 +8,7 @@ import {
   AMQP_PIPELINE_EXECUTION_QUEUE,
   AMQP_PIPELINE_EXECUTION_SUCCESS_TOPIC
 } from '../../env'
+import PipelineExecutionEventHandler from '../pipelineExecutionEventHandler'
 
 export class PipelineExecutionConsumer {
   constructor (

--- a/storage/storage-mq/src/storage-content/postgresStorageContentRepository.ts
+++ b/storage/storage-mq/src/storage-content/postgresStorageContentRepository.ts
@@ -1,7 +1,9 @@
 import { PoolConfig, QueryResult } from 'pg'
-import { StorageContentRepository, StorageContent, InsertStorageContent } from './storageContentRepository'
-import PostgresRepository from '@/util/postgresRepository'
+
+import PostgresRepository from '../util/postgresRepository'
 import { POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PW, POSTGRES_DB, POSTGRES_SCHEMA } from '../env'
+
+import { StorageContentRepository, StorageContent, InsertStorageContent } from './storageContentRepository'
 
 const EXISTS_TABLE_STATEMENT = (schema: string, table: string): string => `SELECT to_regclass('"${schema}"."${table}"')`
 const GET_ALL_CONTENT_STATEMENT = (schema: string, table: string): string => `SELECT * FROM "${schema}"."${table}"`

--- a/storage/storage-mq/src/storage-structure/postgresStorageStructureRepository.ts
+++ b/storage/storage-mq/src/storage-structure/postgresStorageStructureRepository.ts
@@ -1,7 +1,9 @@
-import { StorageStructureRepository } from './storageStructureRepository'
 import { PoolConfig } from 'pg'
+
 import { POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PW, POSTGRES_DB, POSTGRES_SCHEMA } from '../env'
-import PostgresRepository from '@/util/postgresRepository'
+import PostgresRepository from '../util/postgresRepository'
+
+import { StorageStructureRepository } from './storageStructureRepository'
 
 const CREATE_BUCKET_STATEMENT =
 (schema: string, table: string): string => `CREATE TABLE IF NOT EXISTS "${schema}"."${table}" (

--- a/storage/storage-mq/src/storage-structure/storageStructureRepository.ts
+++ b/storage/storage-mq/src/storage-structure/storageStructureRepository.ts
@@ -1,4 +1,3 @@
-
 export interface StorageStructureRepository {
   init: (retries: number, backoff: number) => Promise<void>
 

--- a/storage/storage-mq/tsconfig.json
+++ b/storage/storage-mq/tsconfig.json
@@ -3,21 +3,15 @@
     "target": "es2018",
     "module": "commonjs",
     "strict": true,
-    "jsx": "preserve",
-    "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "allowJs": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
     "lib": ["es2018"],
     "outDir": "dist"
   },
   "include": [
-    "src/**/*.ts",
-  ],
-  "exclude": ["node_modules"]
+    "src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
Currently, our TypeScript config allows absolute imports with `@/...`. Those imports won't be transformed into relative imports by tsc. Because NodeJS does not understand these absolute imports with `@/...`, support for them is removed in this PR.