### PR TITLE
Adapter: Refactor response status

### DIFF
--- a/adapter/integration-test/src/adapter-datasource-trigger.test.js
+++ b/adapter/integration-test/src/adapter-datasource-trigger.test.js
@@ -154,7 +154,7 @@ describe('Datasource triggering', () => {
 
   test('Should publish results for datasources with invalid location [POST /datasources/{id}/trigger]', async () => {
     const brokenDatasourceConfig = Object.assign({}, staticDatasourceConfig)
-    brokenDatasourceConfig.protocol.parameters.location = 'LOL'
+    brokenDatasourceConfig.protocol.parameters.location = 'invalid-location'
     const datasourceResponse = await request(ADAPTER_URL)
       .post('/datasources')
       .send(brokenDatasourceConfig)

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -213,6 +213,13 @@ describe('Datasource Configuration', () => {
     expect(getDeletedRequest.status).toEqual(404)
   }, TIMEOUT)
 
+  test('Should return 404 NOT FOUND when deleting unknown datasource [DELETE /datasources/0]', async () => {
+    const delResponse = await request(ADAPTER_URL)
+      .delete('/datasources/0')
+      .send()
+    expect(delResponse.status).toEqual(404)
+  }, TIMEOUT)
+
   test('Should delete all datasources [DELETE /datasources/]', async () => {
     await request(ADAPTER_URL)
       .post('/datasources')

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -80,7 +80,7 @@ describe('Datasource Configuration', () => {
 
   test('Should not create datasource with unsupported protocol [POST /datasources]', async () => {
     const invalidDatasourceConfig = getDatasourceConfig()
-    invalidDatasourceConfig.protocol.type = 'LOL'
+    invalidDatasourceConfig.protocol.type = 'UNSUPPORTED'
     const datasourceResponse = await request(ADAPTER_URL)
       .post('/datasources')
       .send(invalidDatasourceConfig)
@@ -90,7 +90,7 @@ describe('Datasource Configuration', () => {
 
   test('Should not create datasource with unsupported format [POST /datasources]', async () => {
     const invalidDatasourceConfig = getDatasourceConfig()
-    invalidDatasourceConfig.format.type = 'LOL'
+    invalidDatasourceConfig.format.type = 'UNSUPPORTED'
     const datasourceResponse = await request(ADAPTER_URL)
       .post('/datasources')
       .send(invalidDatasourceConfig)
@@ -142,7 +142,7 @@ describe('Datasource Configuration', () => {
     expect(originalGetResponse.status).toEqual(200)
 
     const invalidDatasourceConfig = getDatasourceConfig()
-    invalidDatasourceConfig.protocol.type = 'LOL'
+    invalidDatasourceConfig.protocol.type = 'UNSUPPORTED'
     const datasourceResponse = await request(ADAPTER_URL)
       .put('/datasources/' + datasourceId)
       .send(invalidDatasourceConfig)
@@ -172,7 +172,7 @@ describe('Datasource Configuration', () => {
     expect(originalGetResponse.status).toEqual(200)
 
     const invalidDatasourceConfig = getDatasourceConfig()
-    invalidDatasourceConfig.format.type = 'LOL'
+    invalidDatasourceConfig.format.type = 'UNSUPPORTED'
     const datasourceResponse = await request(ADAPTER_URL)
       .put('/datasources/' + datasourceId)
       .send(invalidDatasourceConfig)

--- a/adapter/integration-test/src/adapter-stateless.test.js
+++ b/adapter/integration-test/src/adapter-stateless.test.js
@@ -142,4 +142,80 @@ describe('Stateless data import', () => {
       }
     ])
   }, TIMEOUT)
+
+  test('Should return 400 BAD_REQUEST for invalid protocol [POST /dataImport]', async () => {
+    const reqBody = {
+      protocol: {
+        type: 'LOL',
+        parameters: {
+          location: MOCK_SERVER_URL + '/json',
+          encoding: 'UTF-8'
+        }
+      },
+      format: {
+        type: 'JSON'
+      }
+    }
+    const response = await request(ADAPTER_URL)
+      .post('/dataImport')
+      .send(reqBody)
+    expect(response.status).toEqual(400)
+  }, TIMEOUT)
+
+  test('Should return 400 BAD_REQUEST for invalid format [POST /dataImport]', async () => {
+    const reqBody = {
+      protocol: {
+        type: 'HTTP',
+        parameters: {
+          location: MOCK_SERVER_URL + '/json',
+          encoding: 'UTF-8'
+        }
+      },
+      format: {
+        type: 'LOL'
+      }
+    }
+    const response = await request(ADAPTER_URL)
+      .post('/dataImport')
+      .send(reqBody)
+    expect(response.status).toEqual(400)
+  }, TIMEOUT)
+
+  test('Should return 400 BAD_REQUEST for invalid location [POST /dataImport]', async () => {
+    const reqBody = {
+      protocol: {
+        type: 'HTTP',
+        parameters: {
+          location: 'LOL',
+          encoding: 'UTF-8'
+        }
+      },
+      format: {
+        type: 'LOL'
+      }
+    }
+    const response = await request(ADAPTER_URL)
+      .post('/dataImport')
+      .send(reqBody)
+    expect(response.status).toEqual(400)
+  }, TIMEOUT)
+
+  test('Should return 400 BAD_REQUEST for data not found [POST /dataImport]', async () => {
+    const reqBody = {
+      protocol: {
+        type: 'HTTP',
+        parameters: {
+          location: MOCK_SERVER_URL + '/not-found',
+          encoding: 'UTF-8'
+        }
+      },
+      format: {
+        type: 'LOL'
+      }
+    }
+    const response = await request(ADAPTER_URL)
+      .post('/dataImport')
+      .send(reqBody)
+    expect(response.status).toEqual(400)
+  }, TIMEOUT)
 })

--- a/adapter/integration-test/src/adapter-stateless.test.js
+++ b/adapter/integration-test/src/adapter-stateless.test.js
@@ -143,10 +143,10 @@ describe('Stateless data import', () => {
     ])
   }, TIMEOUT)
 
-  test('Should return 400 BAD_REQUEST for invalid protocol [POST /dataImport]', async () => {
+  test('Should return 400 BAD_REQUEST for unsupported protocol [POST /dataImport]', async () => {
     const reqBody = {
       protocol: {
-        type: 'LOL',
+        type: 'UNSUPPORTED',
         parameters: {
           location: MOCK_SERVER_URL + '/json',
           encoding: 'UTF-8'
@@ -162,7 +162,7 @@ describe('Stateless data import', () => {
     expect(response.status).toEqual(400)
   }, TIMEOUT)
 
-  test('Should return 400 BAD_REQUEST for invalid format [POST /dataImport]', async () => {
+  test('Should return 400 BAD_REQUEST for unsupported format [POST /dataImport]', async () => {
     const reqBody = {
       protocol: {
         type: 'HTTP',
@@ -172,7 +172,7 @@ describe('Stateless data import', () => {
         }
       },
       format: {
-        type: 'LOL'
+        type: 'UNSUPPORTED'
       }
     }
     const response = await request(ADAPTER_URL)
@@ -186,12 +186,12 @@ describe('Stateless data import', () => {
       protocol: {
         type: 'HTTP',
         parameters: {
-          location: 'LOL',
+          location: 'invalid-location',
           encoding: 'UTF-8'
         }
       },
       format: {
-        type: 'LOL'
+        type: 'JSON'
       }
     }
     const response = await request(ADAPTER_URL)
@@ -210,7 +210,7 @@ describe('Stateless data import', () => {
         }
       },
       format: {
-        type: 'LOL'
+        type: 'JSON'
       }
     }
     const response = await request(ADAPTER_URL)

--- a/adapter/integration-test/src/mock.server.js
+++ b/adapter/integration-test/src/mock.server.js
@@ -11,6 +11,12 @@ router.get('/', async ctx => {
   ctx.body = 'ok'
 })
 
+router.get('/not-found', async ctx => {
+  ctx.type = 'text/plain'
+  ctx.status = 404
+  ctx.body = '404 NOT FOUND Error'
+})
+
 router.get('/json', async ctx => {
   console.log('GET /json')
   ctx.body = { whateverwillbe: 'willbe', quesera: 'sera' }

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/Adapter.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/Adapter.java
@@ -6,6 +6,7 @@ import org.jvalue.ods.adapterservice.adapter.model.AdapterConfig;
 import org.jvalue.ods.adapterservice.adapter.model.DataBlob;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -21,7 +22,15 @@ public class Adapter {
     this.dataBlobRepository = dataBlobRepository;
   }
 
-  public DataBlob executeJob(AdapterConfig config) {
+  /**
+   * Executes an adapter configuration
+   *
+   * @param config the adapter configuration
+   * @return the imported and interpreted data
+   * @throws IllegalArgumentException on errors in the adapter config (e.g. missing parameters, ...)
+   * @throws RestClientException      on response errors when importing the data
+   */
+  public DataBlob executeJob(AdapterConfig config) throws IllegalArgumentException, RestClientException {
     var importer = config.protocolConfig.protocol.getImporter();
     var interpreter = config.formatConfig.format.getInterpreter();
 

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/api/rest/v1/AdapterEndpoint.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/api/rest/v1/AdapterEndpoint.java
@@ -5,11 +5,11 @@ import org.jvalue.ods.adapterservice.adapter.model.AdapterConfig;
 import org.jvalue.ods.adapterservice.adapter.model.DataBlob;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.validation.Valid;
@@ -29,19 +29,12 @@ public class AdapterEndpoint {
   public DataBlob.MetaData executeDataImport(@Valid @RequestBody AdapterConfig config) {
     try {
       return adapter.executeJob(config).getMetaData();
+    } catch (IllegalArgumentException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid config: " + e.getMessage());
+    } catch (RestClientException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Failed to load data: " + e.getMessage());
     } catch (Exception e) {
-      if (e instanceof HttpMessageNotReadableException) {
-        System.err.println("Data Import request failed. Malformed Request: " + e.getMessage());
-        throw e;
-      }
-      String location = config.protocolConfig.parameters.get("location").toString();
-      if (location != null) {
-        System.err.println("Importing data from " + location + " failed.\n" +
-          "Reason: " + e.getClass().getName() + ": " + e.getMessage());
-      } else {
-        System.err.println("Data Import failed. Reason: " + e.getClass() + ": " + e.getMessage());
-      }
-      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
   }
 }


### PR DESCRIPTION
This PR fixes the second part of #156. Now meaningful HTTP status codes are returned from the REST endpoints of the Adapter.