### PR TITLE
Adapter: allow long URLs

### DIFF
--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -98,6 +98,18 @@ describe('Datasource Configuration', () => {
     expect(datasourceResponse.status).toEqual(400)
   }, TIMEOUT)
 
+  test('Should create datasource with long URL [POST /datasources]', async () => {
+    const longUrlDatasourceConfig = getDatasourceConfig()
+    const queryParameter = '&parameter=longParameter'
+    const longUrl = 'http://www.disresprect.com?first=test' + queryParameter.repeat(20)
+    longUrlDatasourceConfig.protocol.parameters.location = longUrl
+    const response = await request(ADAPTER_URL)
+      .post('/datasources')
+      .send(longUrlDatasourceConfig)
+
+    expect(response.status).toEqual(201)
+  })
+
   test('Should update existing datasource [PUT /datasources/{id}]', async () => {
     const postResponse = await request(ADAPTER_URL)
       .post('/datasources')

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -100,8 +100,8 @@ describe('Datasource Configuration', () => {
 
   test('Should create datasource with long URL [POST /datasources]', async () => {
     const longUrlDatasourceConfig = getDatasourceConfig()
-    const queryParameter = '&veryLongProfessionalParameter=verylongProfessionalParameterValue'
-    const longUrl = 'http://www.very-long-professional-location-that-might-not-fit-in-the-database.com?first=test' + queryParameter.repeat(40)
+    const queryParameter = '&veryLongParameter=verylongParameterValue'
+    const longUrl = 'http://www.very-long-location-that-might-not-fit-in-the-database.com?first=test' + queryParameter.repeat(40)
     longUrlDatasourceConfig.protocol.parameters.location = longUrl
     const response = await request(ADAPTER_URL)
       .post('/datasources')
@@ -120,7 +120,7 @@ describe('Datasource Configuration', () => {
       .get('/datasources/' + createdDatasource.id)
 
     const updatedConfig = getDatasourceConfig()
-    updatedConfig.protocol.parameters.location = 'http://www.professional-location.com'
+    updatedConfig.protocol.parameters.location = 'http://www.location.com'
 
     const putResponse = await request(ADAPTER_URL)
       .put('/datasources/' + createdDatasource.id)
@@ -255,7 +255,7 @@ const getDatasourceConfig = () => ({
   protocol: {
     type: 'HTTP',
     parameters: {
-      location: 'http://www.professional-location.com'
+      location: 'http://www.location.com'
     }
   },
   format: {
@@ -268,7 +268,7 @@ const getDatasourceConfig = () => ({
     interval: 50000
   },
   metadata: {
-    author: 'professional-author',
+    author: 'author',
     license: 'none',
     displayName: 'test datasource 1',
     description: 'integration testing datasources'

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -101,7 +101,7 @@ describe('Datasource Configuration', () => {
   test('Should create datasource with long URL [POST /datasources]', async () => {
     const longUrlDatasourceConfig = getDatasourceConfig()
     const queryParameter = '&parameter=longParameter'
-    const longUrl = 'http://www.disresprect.com?first=test' + queryParameter.repeat(20)
+    const longUrl = 'http://www.verylongdomain.com?first=test' + queryParameter.repeat(20)
     longUrlDatasourceConfig.protocol.parameters.location = longUrl
     const response = await request(ADAPTER_URL)
       .post('/datasources')

--- a/adapter/integration-test/src/adapter-datasource.test.js
+++ b/adapter/integration-test/src/adapter-datasource.test.js
@@ -100,8 +100,8 @@ describe('Datasource Configuration', () => {
 
   test('Should create datasource with long URL [POST /datasources]', async () => {
     const longUrlDatasourceConfig = getDatasourceConfig()
-    const queryParameter = '&parameter=longParameter'
-    const longUrl = 'http://www.verylongdomain.com?first=test' + queryParameter.repeat(20)
+    const queryParameter = '&veryLongProfessionalParameter=verylongProfessionalParameterValue'
+    const longUrl = 'http://www.very-long-professional-location-that-might-not-fit-in-the-database.com?first=test' + queryParameter.repeat(40)
     longUrlDatasourceConfig.protocol.parameters.location = longUrl
     const response = await request(ADAPTER_URL)
       .post('/datasources')
@@ -120,7 +120,7 @@ describe('Datasource Configuration', () => {
       .get('/datasources/' + createdDatasource.id)
 
     const updatedConfig = getDatasourceConfig()
-    updatedConfig.protocol.parameters.location = 'http://www.disrespect.com'
+    updatedConfig.protocol.parameters.location = 'http://www.professional-location.com'
 
     const putResponse = await request(ADAPTER_URL)
       .put('/datasources/' + createdDatasource.id)
@@ -255,7 +255,7 @@ const getDatasourceConfig = () => ({
   protocol: {
     type: 'HTTP',
     parameters: {
-      location: 'http://www.nodisrespect.org'
+      location: 'http://www.professional-location.com'
     }
   },
   format: {
@@ -268,7 +268,7 @@ const getDatasourceConfig = () => ({
     interval: 50000
   },
   metadata: {
-    author: 'icke',
+    author: 'professional-author',
     license: 'none',
     displayName: 'test datasource 1',
     description: 'integration testing datasources'

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/datasource/model/DatasourceProtocol.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/datasource/model/DatasourceProtocol.java
@@ -19,7 +19,7 @@ public class DatasourceProtocol {
   private Protocol type;
 
   @NotNull
-  @Column(name = "protocol_parameters")
+  @Column(name = "protocol_parameters", length = 2000)
   @Convert(converter = GenericParameterConverter.class)
   private Map<String, Object> parameters;
 

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/datasource/model/DatasourceProtocol.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/datasource/model/DatasourceProtocol.java
@@ -19,7 +19,8 @@ public class DatasourceProtocol {
   private Protocol type;
 
   @NotNull
-  @Column(name = "protocol_parameters", length = 2000)
+  @Column(name = "protocol_parameters")
+  @Lob // tells JPA to make the field a BLOB, which results in using the TEXT column type in PostgreSQL
   @Convert(converter = GenericParameterConverter.class)
   private Map<String, Object> parameters;
 


### PR DESCRIPTION
closes #240 .

The `protocol-parameters` are JSONified and then saved in the database. It looks like the standard length for a string field is 255, which I'd argue is too low, especially considering this field does not only contain the url (`location`) but also parameters that can be set inside the URL.

I changed the length to 2000, which is up for discussion.

Also we should add a validation and error message to it, but I honestly have no clue yet where one would add that, but I wanted this fixed for my Corona example. Maybe just open another issue for that? Feedback is appreciated.