### PR TITLE
Adapter data import

### DIFF
--- a/adapter/README.md
+++ b/adapter/README.md
@@ -36,12 +36,12 @@ Support for new protocols or data formats can easily be achieved by adding class
 ## API Docs
 
 ## Adapter API (data import)
-| Endpoint  | Method  | Request Body  | Response Body |
-|---|---|---|---|
+| Endpoint  | Method  | Request Body  | Response Body | Request Parameters
+|---|---|---|---|---|
 | *base_url*/version  | GET  | -  | String containing the application version  |
 | *base_url*/formats  | GET  | -  | JsonArray of data formats available for parsing and possible parameters |
 | *base_url*/protocols  | GET  | -  | JsonArray of protocols available for importing and possible parameters  |
-| *base_url*/dataImport  | POST  | AdapterConfig file  | ImportResponse |
+| *base_url*/dataImport  | POST  | AdapterConfig file  | ImportResponse | includeData: set to True to receive importedData in response instead of a reference
 | *base_url*/data/{id}  | GET  | -  | JSON representation of imported data with {id} |
 
 
@@ -75,11 +75,19 @@ When started via docker-compose *base_url* is `http://localhost:9000/api/adapter
 ```
 
 ### ImportResponse
+```ImportReference || ImportData```
+
+### ImportReference
 ```
 {
     "id": string,
     "location": <<String containing the relative location of the data>>
 }
+```
+
+### ImportData
+```
+The imported data as JSON (both array or object is possible)
 ```
 
 

--- a/adapter/README.md
+++ b/adapter/README.md
@@ -36,7 +36,7 @@ Support for new protocols or data formats can easily be achieved by adding class
 ## API Docs
 
 ## Adapter API (data import)
-| Endpoint  | Method  | Request Body  | Response Body | Request Parameters
+| Endpoint  | Method  | Request Body  | Response Body | Query Parameters
 |---|---|---|---|---|
 | *base_url*/version  | GET  | -  | String containing the application version  |
 | *base_url*/formats  | GET  | -  | JsonArray of data formats available for parsing and possible parameters |

--- a/adapter/integration-test/src/adapter-stateless.test.js
+++ b/adapter/integration-test/src/adapter-stateless.test.js
@@ -73,6 +73,31 @@ describe('Stateless data import', () => {
     expect(dataResponse.body).toEqual({ whateverwillbe: 'willbe', quesera: 'sera' })
   }, TIMEOUT)
 
+  test('Should handle includeData parameter appropriately when requesting a dataImport', async () => {
+    const reqBody = {
+      protocol: {
+        type: 'HTTP',
+        parameters: {
+          location: MOCK_SERVER_URL + '/json',
+          encoding: 'UTF-8'
+        }
+      },
+      format: {
+        type: 'JSON'
+      }
+    }
+
+    const response = await request(ADAPTER_URL)
+      .post('/dataImport')
+      .query('includeData=true')
+      .send(reqBody)
+
+    expect(response.status).toEqual(200)
+    expect(response.body).toEqual({
+      whateverwillbe: 'willbe', quesera: 'sera'
+    })
+  }, TIMEOUT)
+
   test('Should create a XML adapter as importer [POST /dataImport]', async () => {
     const reqBody = {
       protocol: {

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/api/rest/v1/AdapterEndpoint.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/api/rest/v1/AdapterEndpoint.java
@@ -23,7 +23,7 @@ public class AdapterEndpoint {
     this.adapter = adapter;
   }
 
-  @PostMapping(Mappings.IMPORT_PATH)
+  @PostMapping(value = Mappings.IMPORT_PATH, produces = "application/json")
   public ResponseEntity<?> executeDataImport(
           @Valid @RequestBody AdapterConfig config,
           @RequestParam(required = false) boolean includeData) {

--- a/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/api/rest/v1/AdapterEndpoint.java
+++ b/adapter/src/main/java/org/jvalue/ods/adapterservice/adapter/api/rest/v1/AdapterEndpoint.java
@@ -5,10 +5,8 @@ import org.jvalue.ods.adapterservice.adapter.model.AdapterConfig;
 import org.jvalue.ods.adapterservice.adapter.model.DataBlob;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -26,9 +24,18 @@ public class AdapterEndpoint {
   }
 
   @PostMapping(Mappings.IMPORT_PATH)
-  public DataBlob.MetaData executeDataImport(@Valid @RequestBody AdapterConfig config) {
+  public ResponseEntity<?> executeDataImport(
+          @Valid @RequestBody AdapterConfig config,
+          @RequestParam(required = false) boolean includeData) {
     try {
-      return adapter.executeJob(config).getMetaData();
+      DataBlob imported = adapter.executeJob(config);
+
+      if(includeData) {
+        return ResponseEntity.ok(imported.getData());
+      }
+
+      return ResponseEntity.ok(imported.getMetaData());
+
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid config: " + e.getMessage());
     } catch (RestClientException e) {

--- a/doc/example-requests/adapter.http
+++ b/doc/example-requests/adapter.http
@@ -26,6 +26,24 @@ Content-Type: application/json
     }
 }
 
+### Perform data import with response data included
+POST {{baseURL}}/dataImport?includeData=true  HTTP/1.1
+Content-Type: application/json
+
+{
+    "protocol": {
+      "type": "HTTP",
+      "parameters": {
+        "location": "https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json",
+        "encoding": "UTF-8"
+      }
+    },
+    "format": {
+      "type": "JSON",
+      "parameters": {}
+    }
+}
+
 ### Perform Data Import CSV
 POST {{baseURL}}/dataImport  HTTP/1.1
 Content-Type: application/json;charset=UTF-8


### PR DESCRIPTION
Adds an option to the /dataImport endpoint of the datasource service to include the imported data itself instead of a reference. This functionality is needed for the data engineering workbench. Closes #248 