### PR TITLE
[Pipeline] Add express async wrapper

### DIFF
--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -1487,9 +1487,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
+      "integrity": "sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -1499,23 +1499,14 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
-      "integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.14.tgz",
+      "integrity": "sha512-uFTLwu94TfUFMToXNgRZikwPuZdOtDgs3syBtAIr/OXorL1kJqUJT9qCLnRZ5KBOWfZQikQ2xKgR2tnDj1OgDA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "@types/express-session": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.0.tgz",
-      "integrity": "sha512-OQEHeBFE1UhChVIBhRh9qElHUvTp4BzKKHxMDkGHT7WuYk5eL93hPG7D8YAIkoBSbhNEY0RjreF15zn+U0eLjA==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*",
-        "@types/node": "*"
       }
     },
     "@types/graceful-fs": {
@@ -1575,9 +1566,9 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
       "dev": true
     },
     "@types/node": {
@@ -1612,9 +1603,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==",
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
       "dev": true
     },
     "@types/range-parser": {
@@ -1624,13 +1615,13 @@
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
+      "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/stack-utils": {
@@ -3610,33 +3601,6 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
-      }
-    },
-    "express-session": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
-      "integrity": "sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==",
-      "requires": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
-        "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.0",
-        "uid-safe": "~2.1.5"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        }
       }
     },
     "extend": {
@@ -7702,11 +7666,6 @@
         "ee-first": "1.1.1"
       }
     },
-    "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8124,11 +8083,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
-    "random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -9484,14 +9438,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
       "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
-    },
-    "uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "requires": {
-        "random-bytes": "~1.0.0"
-      }
     },
     "union-value": {
       "version": "1.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -18,15 +18,13 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "express-session": "^1.17.1",
     "pg": "^8.3.0",
     "vm2": "^3.8.3"
   },
   "devDependencies": {
     "@types/amqplib": "^0.5.14",
     "@types/cors": "^2.8.6",
-    "@types/express": "^4.17.6",
-    "@types/express-session": "^1.17.0",
+    "@types/express": "^4.17.9",
     "@types/jest": "^25.2.3",
     "@types/supertest": "^2.0.9",
     "@typescript-eslint/eslint-plugin": "^4.4.1",

--- a/pipeline/src/api/rest/pipelineConfigEndpoint.ts
+++ b/pipeline/src/api/rest/pipelineConfigEndpoint.ts
@@ -1,19 +1,20 @@
-import * as express from 'express'
+import express from 'express'
 
 import { PipelineConfigManager } from '../../pipeline-config/pipelineConfigManager'
 import { PipelineConfigDTOValidator } from '../../pipeline-config/model/pipelineConfig'
 import { isString } from '../../validators'
+import { asyncHandler } from './utils'
 
 export class PipelineConfigEndpoint {
   constructor (private readonly pipelineConfigManager: PipelineConfigManager) {}
 
   registerRoutes = (app: express.Application): void => {
-    app.get('/configs', this.getAll)
-    app.get('/configs/:id', this.getOne)
-    app.post('/configs', this.create)
-    app.put('/configs/:id', this.update)
-    app.delete('/configs/:id', this.delete)
-    app.delete('/configs', this.deleteAll)
+    app.get('/configs', asyncHandler(this.getAll))
+    app.get('/configs/:id', asyncHandler(this.getOne))
+    app.post('/configs', asyncHandler(this.create))
+    app.put('/configs/:id', asyncHandler(this.update))
+    app.delete('/configs/:id', asyncHandler(this.delete))
+    app.delete('/configs', asyncHandler(this.deleteAll))
   }
 
   // The following methods need arrow syntax because of javascript 'this' shenanigans

--- a/pipeline/src/api/rest/pipelineExecutionEndpoint.ts
+++ b/pipeline/src/api/rest/pipelineExecutionEndpoint.ts
@@ -1,14 +1,15 @@
-import * as express from 'express'
+import express from 'express'
 
 import PipelineExecutor from '../../pipeline-execution/pipelineExecutor'
 import { PipelineExecutionRequestValidator } from '../pipelineExecutionRequest'
 import { JobResult } from '../../pipeline-execution/jobResult'
+import { asyncHandler } from './utils'
 
 export class PipelineExecutionEndpoint {
   constructor (private readonly pipelineExecutor: PipelineExecutor) {}
 
   registerRoutes = (app: express.Application): void => {
-    app.post('/job', this.postJob)
+    app.post('/job', asyncHandler(this.postJob))
   }
 
   // The following methods need arrow syntax because of javascript 'this' shenanigans

--- a/pipeline/src/api/rest/utils.ts
+++ b/pipeline/src/api/rest/utils.ts
@@ -1,0 +1,14 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+
+/**
+ * A wrapper for promise returning request handlers that passes the value of a
+ * rejected promise to express's `next` function.
+ * @param handler request handler to wrap
+ */
+export function asyncHandler
+(handler: (req: Request, res: Response, next?: NextFunction) => void | Promise<void>): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const handlerResult = handler(req, res, next)
+    Promise.resolve(handlerResult).catch(next)
+  }
+}


### PR DESCRIPTION
Adds an async request handler wrapper so rejected promises are returning a `500`.

I have not added a custom express error as the default one is already logging the error to console and it is responding with status `500`. The body does contain the full stack trace because the `NODE_ENV` environment variable is not set.

I have also removed the unused `express-session` dependency from `package.json`.

See #247 