### PR TITLE
[Storage-MQ] Add express async wrapper

### DIFF
--- a/storage/storage-mq/package-lock.json
+++ b/storage/storage-mq/package-lock.json
@@ -1181,9 +1181,9 @@
             }
         },
         "@types/express": {
-            "version": "4.17.7",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
-            "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
+            "version": "4.17.9",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
+            "integrity": "sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==",
             "dev": true,
             "requires": {
                 "@types/body-parser": "*",
@@ -1193,9 +1193,9 @@
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.17.8",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
-            "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
+            "version": "4.17.14",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.14.tgz",
+            "integrity": "sha512-uFTLwu94TfUFMToXNgRZikwPuZdOtDgs3syBtAIr/OXorL1kJqUJT9qCLnRZ5KBOWfZQikQ2xKgR2tnDj1OgDA==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -1260,9 +1260,9 @@
             "dev": true
         },
         "@types/mime": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-            "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+            "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
             "dev": true
         },
         "@types/node": {
@@ -1300,9 +1300,9 @@
             "dev": true
         },
         "@types/qs": {
-            "version": "6.9.3",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-            "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
+            "version": "6.9.5",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+            "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
             "dev": true
         },
         "@types/range-parser": {
@@ -1312,13 +1312,13 @@
             "dev": true
         },
         "@types/serve-static": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-            "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
+            "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
             "dev": true,
             "requires": {
-                "@types/express-serve-static-core": "*",
-                "@types/mime": "*"
+                "@types/mime": "*",
+                "@types/node": "*"
             }
         },
         "@types/stack-utils": {

--- a/storage/storage-mq/package.json
+++ b/storage/storage-mq/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/amqplib": "^0.5.14",
     "@types/cors": "^2.8.6",
-    "@types/express": "^4.17.6",
+    "@types/express": "^4.17.9",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.23",
     "@types/pg": "^7.14.3",

--- a/storage/storage-mq/src/api/rest/storageContentEndpoint.ts
+++ b/storage/storage-mq/src/api/rest/storageContentEndpoint.ts
@@ -1,5 +1,7 @@
-import * as express from 'express'
+import express from 'express'
+
 import { StorageContentRepository } from '../../storage-content/storageContentRepository'
+import { asyncHandler } from './utils'
 
 export class StorageContentEndpoint {
   private readonly version = '0.0.1'
@@ -9,8 +11,8 @@ export class StorageContentEndpoint {
   // The following methods need arrow syntax because of javascript 'this' shenanigans
 
   registerRoutes = (app: express.Application): void => {
-    app.get('/bucket/:bucketId/content/:contentId', this.handleContentRequest)
-    app.get('/bucket/:bucketId/content', this.handleAllContentRequest)
+    app.get('/bucket/:bucketId/content/:contentId', asyncHandler(this.handleContentRequest))
+    app.get('/bucket/:bucketId/content', asyncHandler(this.handleAllContentRequest))
   }
 
   getVersion = (): string => {

--- a/storage/storage-mq/src/api/rest/utils.ts
+++ b/storage/storage-mq/src/api/rest/utils.ts
@@ -1,0 +1,14 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+
+/**
+ * A wrapper for promise returning request handlers that passes the value of a
+ * rejected promise to express's `next` function.
+ * @param handler request handler to wrap
+ */
+export function asyncHandler
+(handler: (req: Request, res: Response, next?: NextFunction) => void | Promise<void>): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const handlerResult = handler(req, res, next)
+    Promise.resolve(handlerResult).catch(next)
+  }
+}


### PR DESCRIPTION
Adds an async request handler wrapper so rejected promises are returning a `500`.

I have not added a custom express error as the default one is already logging the error to console and it is responding with status `500`. The body does contain the full stack trace because the `NODE_ENV` environment variable is not set.

See #247