### PR TITLE
[Notification] Add express async wrapper

### DIFF
--- a/notification/package-lock.json
+++ b/notification/package-lock.json
@@ -1570,9 +1570,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
-      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
+      "integrity": "sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -1582,24 +1582,14 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
-      "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.14.tgz",
+      "integrity": "sha512-uFTLwu94TfUFMToXNgRZikwPuZdOtDgs3syBtAIr/OXorL1kJqUJT9qCLnRZ5KBOWfZQikQ2xKgR2tnDj1OgDA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "@types/express-session": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.0.tgz",
-      "integrity": "sha512-OQEHeBFE1UhChVIBhRh9qElHUvTp4BzKKHxMDkGHT7WuYk5eL93hPG7D8YAIkoBSbhNEY0RjreF15zn+U0eLjA==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*",
-        "@types/node": "*"
       }
     },
     "@types/graceful-fs": {
@@ -1714,13 +1704,13 @@
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
-      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
+      "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/stack-utils": {
@@ -3963,33 +3953,6 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
-      }
-    },
-    "express-session": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
-      "integrity": "sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==",
-      "requires": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
-        "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.0",
-        "uid-safe": "~2.1.5"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        }
       }
     },
     "extend": {
@@ -7572,11 +7535,6 @@
         "ee-first": "1.1.1"
       }
     },
-    "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8044,11 +8002,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
-    "random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -9529,14 +9482,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
       "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
-    },
-    "uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "requires": {
-        "random-bytes": "~1.0.0"
-      }
     },
     "union-value": {
       "version": "1.0.1",

--- a/notification/package.json
+++ b/notification/package.json
@@ -19,15 +19,13 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "express-session": "^1.17.1",
     "firebase-admin": "^9.2.0",
     "vm2": "^3.9.2"
   },
   "devDependencies": {
     "@types/amqplib": "^0.5.14",
     "@types/cors": "^2.8.7",
-    "@types/express": "^4.17.8",
-    "@types/express-session": "^1.17.0",
+    "@types/express": "^4.17.9",
     "@types/jest": "^26.0.14",
     "@types/supertest": "^2.0.10",
     "@typescript-eslint/eslint-plugin": "^4.4.1",

--- a/notification/src/api/rest/notificationConfigEndpoint.ts
+++ b/notification/src/api/rest/notificationConfigEndpoint.ts
@@ -5,16 +5,17 @@ import {
   NotificationConfig
 } from '../../notification-config/notificationConfig'
 import { NotificationRepository } from '../../notification-config/notificationRepository'
+import { asyncHandler } from './utils'
 
 export class NotificationConfigEndpoint {
   constructor (private readonly storageHandler: NotificationRepository) {}
 
   registerRoutes = (app: express.Application): void => {
-    app.post('/configs', this.handleConfigCreation)
-    app.put('/configs/:id', this.handleConfigUpdate)
-    app.delete('/configs/:id', this.handleConfigDeletion)
-    app.get('/configs/:id', this.handleConfigRetrieve)
-    app.get('/configs', this.handleAllConfigRetrieve)
+    app.post('/configs', asyncHandler(this.handleConfigCreation))
+    app.put('/configs/:id', asyncHandler(this.handleConfigUpdate))
+    app.delete('/configs/:id', asyncHandler(this.handleConfigDeletion))
+    app.get('/configs/:id', asyncHandler(this.handleConfigRetrieve))
+    app.get('/configs', asyncHandler(this.handleAllConfigRetrieve))
   }
 
   /**

--- a/notification/src/api/rest/notificationExecutionEndpoint.ts
+++ b/notification/src/api/rest/notificationExecutionEndpoint.ts
@@ -2,12 +2,13 @@ import express from 'express'
 
 import { PipelineSuccessEvent, isValidPipelineSuccessEvent } from '../pipelineEvent'
 import { TriggerEventHandler } from '../triggerEventHandler'
+import { asyncHandler } from './utils'
 
 export class NotificationExecutionEndpoint {
   constructor (private readonly triggerEventHandler: TriggerEventHandler) {}
 
   registerRoutes = (app: express.Application): void => {
-    app.post('/trigger', this.triggerNotification)
+    app.post('/trigger', asyncHandler(this.triggerNotification))
   }
 
   triggerNotification = async (req: express.Request, res: express.Response): Promise<void> => {

--- a/notification/src/api/rest/utils.ts
+++ b/notification/src/api/rest/utils.ts
@@ -1,0 +1,14 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+
+/**
+ * A wrapper for promise returning request handlers that passes the value of a
+ * rejected promise to express's `next` function.
+ * @param handler request handler to wrap
+ */
+export function asyncHandler
+(handler: (req: Request, res: Response, next?: NextFunction) => void | Promise<void>): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const handlerResult = handler(req, res, next)
+    Promise.resolve(handlerResult).catch(next)
+  }
+}


### PR DESCRIPTION
Adds an async request handler wrapper so rejected promises are returning a `500`.

I have not added a custom express error as the default one is already logging the error to console and it is responding with status `500`. The body does contain the full stack trace because the `NODE_ENV` environment variable is not set.

I have also removed the unused `express-session` dependency from `package.json`.

See #247