### PR TITLE
Git: set eol conversion attribute for Dockerfiles (#259)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile text eol=lf


### PR DESCRIPTION
Fixes git auto conversion of line endings. See  #259 for context.