### PR TITLE
Cleanup traefik labels in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ This configuration can be done programmatically via the API or browser based wit
 ## Using the API
 There is a collection of examples for entire configurations in our [example request collection](doc/example-requests/).
 
-Additionally, there is is swagger API documentation available under `localhost:9400`. 
-The swagger integration is currently in progress, so there is only documentation for the storage service available.
-
 ## Using the UI
 
 The easiest way to use the ODS is via the UI. If you started the ODS with docker-compose you can access the UI under `http://localhost:9000/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.to-ui.rule=PathPrefix(`/`)"
-      - "traefik.http.services.ui.loadbalancer.server.port=80"
 
   # ----------------- ADAPTER SERVICE (/adapter) --------------------
   adapter:
@@ -47,7 +46,6 @@ services:
       - "traefik.http.routers.to-adapter.rule=PathPrefix(`/api/adapter`)"
       - "traefik.http.routers.to-adapter.middlewares=adapter-stripprefix@docker"
       - "traefik.http.middlewares.adapter-stripprefix.stripprefix.prefixes=/api/adapter"
-      - "traefik.http.services.adapter.loadbalancer.server.port=8080"
 
   adapter-db:
     image: postgres
@@ -117,7 +115,6 @@ services:
       - "traefik.http.routers.to-storage-mq.rule=PathPrefix(`/api/storage-mq`)"
       - "traefik.http.routers.to-storage-mq.middlewares=storage-mq-stripprefix@docker"
       - "traefik.http.middlewares.storage-mq-stripprefix.stripprefix.prefixes=/api/storage-mq"
-      - "traefik.http.services.storage-mq.loadbalancer.server.port=8080"
 
   storage: # Wraps postgres database with API
     image: ${DOCKER_REGISTRY}/storage
@@ -138,7 +135,6 @@ services:
       - "traefik.http.routers.to-storage.middlewares=storage-stripprefix@docker,storage-addaccept@docker"
       - "traefik.http.middlewares.storage-stripprefix.stripprefix.prefixes=/api/storage"
       - "traefik.http.middlewares.storage-addaccept.headers.customrequestheaders.Accept=application/json" # Firefox Browser Support
-      - "traefik.http.services.storage.loadbalancer.server.port=3000"
 
   storage-db:
     image: postgres:12-alpine
@@ -209,7 +205,6 @@ services:
       - "traefik.http.routers.to-pipeline.rule=PathPrefix(`/api/pipelines`)"
       - "traefik.http.routers.to-pipeline.middlewares=pipeline-stripprefix@docker"
       - "traefik.http.middlewares.pipeline-stripprefix.stripprefix.prefixes=/api/pipelines"
-      - "traefik.http.services.pipeline.loadbalancer.server.port=8080"
 
   pipeline-db:
     image: postgres
@@ -249,7 +244,6 @@ services:
       - "traefik.http.routers.to-notification.rule=PathPrefix(`/api/notification`)"
       - "traefik.http.routers.to-notification.middlewares=notification-stripprefix@docker"
       - "traefik.http.middlewares.notification-stripprefix.stripprefix.prefixes=/api/notification"
-      - "traefik.http.services.notification.loadbalancer.server.port=8080"
 
   notification-db:
     image: postgres
@@ -282,10 +276,10 @@ services:
       RABBITMQ_DEFAULT_PASS: 'R4bb!7_4DM_p4SS'
     labels:
         - "traefik.enable=true"
-        - "traefik.http.routers.to-amqp.rule=PathPrefix(`/api/amqp`)"
+        - "traefik.http.routers.to-amqp.rule=PathPrefix(`/api/amqp/`)"
         - "traefik.http.routers.to-amqp.middlewares=amqp-stripprefix@docker"
-        - "traefik.http.middlewares.amqp-stripprefix.stripprefix.prefixes=/api/amqp"
-        - "traefik.http.services.amqp.loadbalancer.server.port=8080"
+        - "traefik.http.middlewares.amqp-stripprefix.stripprefix.prefixes=/api/amqp/"
+        - "traefik.http.services.amqp.loadbalancer.server.port=15672"
     ports:
       - "15672:15672"
       - "5672:5672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,10 +146,11 @@ services:
   # volumes:
   #   - "./pgdata:/var/lib/postgresql/data"
 
-  storage-db-ui: # management UI for Postgres
-    image: adminer
-    ports:
-      - 8080:8080
+  # Uncomment this if you want to manage the Postgres databases with adminer
+  # adminer: # management UI for Postgres
+  #   image: adminer
+  #   ports:
+  #     - 8080:8080
 
   storage-db-liquibase: # perform database migration on start up
     image: ${DOCKER_REGISTRY}/storage-db-liquibase
@@ -164,11 +165,6 @@ services:
       CONNECTION_BACKOFF_IN_SECONDS: 2
     depends_on:
       - storage-db
-
-  storage-swagger: # API documentation for storage service
-    image: swaggerapi/swagger-ui
-    environment:
-      API_URL: http://localhost:9400/
 
   # ----------------- PIPELINE SERVICE (/pipelines) --------------------
   pipeline:
@@ -274,12 +270,6 @@ services:
       RABBITMQ_ERLANG_COOKIE: 'S0m3_R4bBi7_C0ok13'
       RABBITMQ_DEFAULT_USER: 'rabbit_adm'
       RABBITMQ_DEFAULT_PASS: 'R4bb!7_4DM_p4SS'
-    labels:
-        - "traefik.enable=true"
-        - "traefik.http.routers.to-amqp.rule=PathPrefix(`/api/amqp/`)"
-        - "traefik.http.routers.to-amqp.middlewares=amqp-stripprefix@docker"
-        - "traefik.http.middlewares.amqp-stripprefix.stripprefix.prefixes=/api/amqp/"
-        - "traefik.http.services.amqp.loadbalancer.server.port=15672"
     ports:
       - "15672:15672"
       - "5672:5672"


### PR DESCRIPTION
Currently, only some of our microservices are defining the `traefik.http.services.<service-name>.loadbalancer.server.port=<port>` label. According to the [Traefik documentation](https://doc.traefik.io/traefik/providers/docker/#port-detection), this label is not required when the container is exposing exactly one port. As all services expose only one port (see the `EXPOSE` statement in the `Dockerfile`s), I would remove this label everywhere.

The RabbitMQ management UI is currently accessible directly via `localhost:15672`. And there is a traefik route `/api/amqp` configured too, which I have fixed to use the correct port. 

But actually, I think that we should not expose the RabbitMQ Management UI under `/api/amqp` as it is only for administration purposes. Therefore I would like to remove exposing it under `/api/amqp`. What do you think? @georg-schwarz @mathiaszinnen @lunedis If you are ok with that I am going to update this PR.