### PR TITLE
Enable colors and verbose output for all jest runs

### DIFF
--- a/notification/integration-test/package.json
+++ b/notification/integration-test/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "mock:receiver": "node src/mock.receiver.js",
     "pretest": "npm run mock:receiver &",
-    "test": "jest",
+    "test": "jest --colors --verbose",
     "posttest": "killall node",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0"

--- a/notification/package.json
+++ b/notification/package.json
@@ -9,7 +9,7 @@
     "transpile": "tsc",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0",
-    "test": "jest"
+    "test": "jest --colors --verbose"
   },
   "dependencies": {
     "@jvalue/node-dry-amqp": "0.0.1",

--- a/pipeline/integration-test/package.json
+++ b/pipeline/integration-test/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Pipeline Service Integration-Tests",
   "scripts": {
-    "test": "jest --runInBand",
+    "test": "jest --colors --verbose --runInBand",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0"
   },

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -9,7 +9,7 @@
     "transpile": "tsc",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0",
-    "test": "jest"
+    "test": "jest --colors --verbose"
   },
   "dependencies": {
     "@jvalue/node-dry-amqp": "0.0.1",

--- a/scheduler/integration-test/package.json
+++ b/scheduler/integration-test/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "mock:adapter": "node src/mock.adapter.js",
     "pretest": "npm run mock:adapter &",
-    "test": "jest --runInBand",
+    "test": "jest --colors --verbose --runInBand",
     "posttest": "killall node",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0"

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -9,7 +9,7 @@
     "transpile": "tsc",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0",
-    "test": "jest"
+    "test": "jest --colors --verbose"
   },
   "dependencies": {
     "amqplib": "^0.6.0",

--- a/storage/storage-mq/package.json
+++ b/storage/storage-mq/package.json
@@ -9,7 +9,7 @@
     "transpile": "tsc",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0",
-    "test": "jest --passWithNoTests"
+    "test": "jest --colors --verbose --passWithNoTests"
   },
   "dependencies": {
     "amqplib": "^0.6.0",

--- a/system-test/package.json
+++ b/system-test/package.json
@@ -4,7 +4,7 @@
   "description": "Open Data Service System Test",
   "scripts": {
     "mockServer": "node src/mock.server.js",
-    "test": "jest src/*.test.js --runInBand --verbose",
+    "test": "jest src/*.test.js --colors --verbose --runInBand",
     "posttest": "killall node",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0"


### PR DESCRIPTION
When testing my changes to the docker image versions, I noticed that the output of the `adapter-it` test is way more pretty and colorful than the others.

So I made all jest jobs use the `--color` and `--verbose` options.

Lemme know if this is not wanted. I just think it looks nicer.