### PR TITLE
fix(ui): avoid range error when setting first execution date

### DIFF
--- a/ui/src/components/DateTimePicker.vue
+++ b/ui/src/components/DateTimePicker.vue
@@ -62,6 +62,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop, Watch } from 'vue-property-decorator'
+import { getISODateString, getISOTimeString } from "./date-helpers";
 
 /**
  * DateTimePicker takes a Date via v-model as input and lets the user select it.
@@ -105,8 +106,8 @@ export default class DateTimePicker extends Vue {
   }
 
   private resetValues (): void {
-    this.date = this.getISODateString(this.value)
-    this.time = this.getISOTimeString(this.value)
+    this.date = getISODateString(this.value)
+    this.time = getISOTimeString(this.value)
     this.dateTimeString = `${this.date} ${this.time}`
   }
 
@@ -117,36 +118,9 @@ export default class DateTimePicker extends Vue {
   }
 
   private onSave (): void {
-    const selectedDate = new Date(
-      this.sliceYearFromDateString(this.date),
-      this.sliceMonthFromDateString(this.date) - 1,
-      this.sliceDayFromDateString(this.date),
-      this.sliceHourFromTimeString(this.time),
-      this.sliceMinuteFromTimeString(this.time)
-    )
-
-    console.log(`Selected Date ${selectedDate.toISOString()}`)
-    this.$emit('input', selectedDate) // update parent
+    const selectedDate = new Date(`${this.date} ${this.time}`);
+    
+    this.$emit('input', selectedDate)
   }
-
-  /**
-   * Get the date part of the given date using the browser's local time in ISO format: `YYYY-MM-DD`
-   */
-  private getISODateString = (date: Date): string => `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
-
-  /**
-   * Get the time part of the given date using the browser's local time in ISO format: `hh:mm`
-   */
-  private getISOTimeString = (date: Date): string => `${date.getHours()}:${date.getMinutes()}`
-
-  private sliceYearFromDateString = (v: string): number => Number(v.slice(0, 4))
-
-  private sliceMonthFromDateString = (v: string): number => Number(v.slice(5, 7))
-
-  private sliceDayFromDateString = (v: string): number => Number(v.slice(8, 10))
-
-  private sliceHourFromTimeString = (v: string): number => Number(v.slice(0, 2))
-
-  private sliceMinuteFromTimeString = (v: string): number => Number(v.slice(3, 5))
 }
 </script>

--- a/ui/src/components/date-helpers.ts
+++ b/ui/src/components/date-helpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Get the date part of the given date using the browser's local time in ISO format: `YYYY-MM-DD`
+ *
+ * @example
+ * getISODateString(new Date('2020-12-1')) // "2020-12-01"
+ */
+export const getISODateString = (date: Date): string => {
+  const year = `${date.getFullYear()}`
+  const months = `0${date.getMonth() + 1}`.replace(/0(\d\d)/, '$1')
+  const days = `0${date.getDate()}`.replace(/0(\d\d)/, '$1')
+
+  return `${year}-${months}-${days}`
+}
+
+/**
+ * Get the time part of the given date using the browser's local time in ISO format: `HH:mm`
+ *
+ * @example
+ * getISOTimeString(new Date('2020-12-1 14:1')) // "14:01"
+ */
+export const getISOTimeString = (date: Date): string => {
+  const hours = `0${date.getHours()}`.replace(/0(\d\d)/, '$1')
+  const minutes = `0${date.getMinutes()}`.replace(/0(\d\d)/, '$1')
+
+  return `${hours}:${minutes}`
+}

--- a/ui/tests/unit/date-helpers.spec.ts
+++ b/ui/tests/unit/date-helpers.spec.ts
@@ -1,0 +1,33 @@
+import { getISODateString, getISOTimeString } from '@/components/date-helpers'
+
+describe('#getISOTimeString', () => {
+  it('should return a date\'s minutes and hours as "hh:mm"', () => {
+    const date1 = new Date('2020-12-5 14:45')
+    const date2 = new Date('2020-12-5 14:4')
+    const date3 = new Date('2020-12-5 4:15')
+    const date4 = new Date('2020-12-5 4:4')
+
+    const date1Actual = getISOTimeString(date1)
+    const date2Actual = getISOTimeString(date2)
+    const date3Actual = getISOTimeString(date3)
+    const date4Actual = getISOTimeString(date4)
+
+    expect(date1Actual).toEqual('14:45')
+    expect(date2Actual).toEqual('14:04')
+    expect(date3Actual).toEqual('04:15')
+    expect(date4Actual).toEqual('04:04')
+  })
+})
+
+describe('#getISODateString', () => {
+  it('should return a date as "HH:mm"', () => {
+    const date1 = new Date('2020-12-5')
+    const date2 = new Date('2020-1-5')
+
+    const date1Actual = getISODateString(date1)
+    const date2Actual = getISODateString(date2)
+
+    expect(date1Actual).toEqual('2020-12-05')
+    expect(date2Actual).toEqual('2020-01-05')
+  })
+})


### PR DESCRIPTION
`sliceMinuteFromTimeString` and `sliceHourFromTimeString` expect a time string in _HH:mm_ format  e.g. "12:01".
`getISOTimeString` generates a time string in _H:m_ format e.g. "12:1".

This leads to a RangeError when clicking "Ok" without changing the default time (returned by `getISOTimeString` and set during component load) in the time-picker within the datasource form.

**This PR**
1. Changes `getISOTimeString` to return the time in the actual ISO format "HH:mm"
2. Removes slice methods for date and time strings. A date can just be initialized like so: `new Date(this.date + ' ' + this.time) `
3. Moves the getISOString methods to helper file for potential reuse (Following the general ODS theme)
4. Adds tests to validate correct format

