### PR TITLE
Refactor scheduler

### DIFF
--- a/scheduler/integration-test/src/mock.adapter.js
+++ b/scheduler/integration-test/src/mock.adapter.js
@@ -1,10 +1,11 @@
-
 const Koa = require('koa')
 const Router = require('koa-router')
-const router = new Router()
-const app = new Koa()
+
 const { MOCK_SERVER_PORT } = require('./env')
 const { jsonDateAfter } = require('./testHelper')
+
+const router = new Router()
+const app = new Koa()
 
 const triggerRequests = new Map()
 const initialSources = [
@@ -13,7 +14,7 @@ const initialSources = [
     trigger: {
       firstExecution: jsonDateAfter(1000),
       periodic: true,
-      interval: 3000
+      interval: 1000
     }
   }
 ]

--- a/scheduler/src/initializer.test.ts
+++ b/scheduler/src/initializer.test.ts
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+import { mocked } from 'ts-jest/utils'
+
+import { getAllDatasources } from './api/http/adapter-client'
+import Scheduler from './scheduling'
+import { initSchedulerWithRetry } from './initializer'
+
+jest.mock('./api/http/adapter-client')
+const mockedGetAllDatasources = mocked(getAllDatasources)
+
+jest.mock('./env', () => ({ MAX_TRIGGER_RETRIES: 2 }))
+
+const CONNECTION_RETRIES = 2
+const CONNECTION_BACKOFF_IN_MS = 1000
+const TRIGGER_RETRIES = 3
+
+let scheduler: Scheduler
+
+describe('Scheduler initializer', () => {
+  beforeEach(() => {
+    scheduler = new Scheduler(TRIGGER_RETRIES)
+  })
+
+  afterEach(() => {
+    scheduler.removeAllJobs()
+  })
+
+  test('should initialize jobs correctly', async () => {
+    const config = {
+      id: 123,
+      trigger: {
+        periodic: false,
+        firstExecution: new Date(),
+        interval: 60000
+      }
+    }
+    mockedGetAllDatasources.mockResolvedValue([config])
+
+    await initSchedulerWithRetry(scheduler, CONNECTION_RETRIES, CONNECTION_BACKOFF_IN_MS)
+    expect(scheduler.getAllJobs()).toHaveLength(1)
+    expect(scheduler.getAllJobs()[0].datasourceConfig).toEqual(config)
+  })
+})

--- a/scheduler/src/initializer.ts
+++ b/scheduler/src/initializer.ts
@@ -1,0 +1,32 @@
+import { sleep } from './sleep'
+import DatasourceConfig from './api/datasource-config'
+import { getAllDatasources } from './api/http/adapter-client'
+import Scheduler from './scheduling'
+
+export async function initSchedulerWithRetry (scheduler: Scheduler, retries: number, backoff: number): Promise<void> {
+  for (let i = 1; i <= retries; i++) {
+    try {
+      await initScheduler(scheduler)
+      return
+    } catch (e) {
+      if (e.code === 'ECONNREFUSED' || e.code === 'ENOTFOUND') {
+        console.warn(`Failed to sync with Adapter Service on init (${retries}) . Retrying after ${backoff}ms... `)
+      } else {
+        console.warn(e)
+        console.warn(`Retrying (${retries})...`)
+      }
+      await sleep(backoff)
+    }
+  }
+  throw new Error('Failed to initialize datasource/pipeline scheduler.')
+}
+
+async function initScheduler (scheduler: Scheduler): Promise<void> {
+  console.log('Starting scheduler initialization')
+  const datasources: DatasourceConfig[] = await getAllDatasources()
+  console.log(`Received ${datasources.length} datasources from adapter-service`)
+  for (const datasource of datasources) {
+    datasource.trigger.firstExecution = new Date(datasource.trigger.firstExecution)
+    await scheduler.upsertJob(datasource) // assuming adapter service checks for duplicates
+  }
+}

--- a/scheduler/src/scheduling.ts
+++ b/scheduler/src/scheduling.ts
@@ -1,64 +1,38 @@
-import type { AxiosError } from 'axios'
 import deepEqual from 'deep-equal'
 import schedule from 'node-schedule'
 
-import * as AdapterClient from './api/http/adapter-client'
 import type DatasourceConfig from './api/datasource-config'
-
-import { sleep } from './sleep'
-import { DatasourceConfigEvent } from './api/amqp/datasourceConfigConsumer'
+import { triggerDatasource } from './trigger-handler'
 
 export default class Scheduler {
-  constructor (private readonly triggerRetries: number) {
-  }
-
   private readonly allJobs: Map<number, SchedulingJob> = new Map() // datasourceId -> job
 
-  async initializeJobsWithRetry (retries: number, backoff: number): Promise<void> {
-    for (let i = 1; i <= retries; i++) {
-      try {
-        await this.initializeJobs()
-        return
-      } catch (e) {
-        if (e.code === 'ECONNREFUSED' || e.code === 'ENOTFOUND') {
-          console.warn(`Failed to sync with Adapter Service on init (${retries}) . Retrying after ${backoff}ms... `)
-        } else {
-          console.warn(e)
-          console.warn(`Retrying (${retries})...`)
-        }
-        await sleep(backoff)
-      }
-    }
-    throw new Error('Failed to initialize datasource/pipeline scheduler.')
-  }
-
-  async initializeJobs (): Promise<void> {
-    console.log('Starting scheduler initialization')
-    const datasources: DatasourceConfig[] = await AdapterClient.getAllDatasources()
-    console.log(`Received ${datasources.length} datasources from adapter-service`)
-    for (const datasource of datasources) {
-      datasource.trigger.firstExecution = new Date(datasource.trigger.firstExecution)
-      await this.upsertJob(datasource) // assuming adapter service checks for duplicates
-    }
-  }
-
-  applyDeleteEvent (event: DatasourceConfigEvent): void {
-    this.cancelJob(event.datasource.id)
-    this.allJobs.delete(event.datasource.id)
-  }
-
-  async applyCreateOrUpdateEvent (event: DatasourceConfigEvent): Promise<void> {
-    const datasource = event.datasource
-    datasource.trigger.firstExecution = new Date(event.datasource.trigger.firstExecution)
-    await this.upsertJob(datasource)
+  constructor (private readonly triggerRetries: number) {
   }
 
   getJob (datasourceId: number): SchedulingJob | undefined {
     return this.allJobs.get(datasourceId)
   }
 
+  getAllJobs (): SchedulingJob[] {
+    return Array.from(this.allJobs.values())
+  }
+
   removeJob (datasourceId: number): void {
+    this.cancelJob(datasourceId)
     this.allJobs.delete(datasourceId)
+  }
+
+  removeAllJobs (): void {
+    this.allJobs.forEach(job => {
+      schedule.cancelJob(job.scheduleJob)
+    })
+    this.allJobs.clear()
+  }
+
+  private cancelJob (jobId: number): void {
+    const job = this.allJobs.get(jobId)
+    job?.scheduleJob.cancel()
   }
 
   existsJob (datasourceId: number): boolean {
@@ -83,21 +57,29 @@ export default class Scheduler {
     return new Date(executionDate)
   }
 
-  scheduleDatasource (datasourceConfig: DatasourceConfig): SchedulingJob {
-    const executionDate: Date = this.determineExecutionDate(datasourceConfig)
-    console.log(`datasource ${datasourceConfig.id} with consecutive pipelines scheduled
-      for next execution at ${executionDate.toLocaleString()}.`)
-
+  private scheduleDatasource (datasourceConfig: DatasourceConfig): SchedulingJob {
     const datasourceId = datasourceConfig.id
 
-    const scheduledJob = schedule.scheduleJob(`Datasource ${datasourceId}`, executionDate, () => {
-      this.execute(datasourceConfig)
-        .catch(error => console.log('Failed to execute job:', error))
-    })
+    // Cancel current job for given datasource
+    this.cancelJob(datasourceId)
+
+    const executionDate: Date = this.determineExecutionDate(datasourceConfig)
+    console.log(`datasource ${datasourceId} with consecutive pipelines scheduled
+      for next execution at ${executionDate.toLocaleString()}.`)
+
+    const scheduledJob = schedule.scheduleJob(`Datasource ${datasourceId}`, executionDate,
+      () => this.execute(datasourceConfig))
     const datasourceJob = { scheduleJob: scheduledJob, datasourceConfig: datasourceConfig }
     this.allJobs.set(datasourceId, datasourceJob)
 
     return datasourceJob
+  }
+
+  private execute (datasourceConfig: DatasourceConfig): void {
+    const datasourceId = datasourceConfig.id
+    triggerDatasource(datasourceId, this.triggerRetries)
+      .catch(error => console.log('Failed to execute job:', error))
+      .finally(() => this.reschedule(datasourceConfig))
   }
 
   reschedule (datasourceConfig: DatasourceConfig): void {
@@ -110,75 +92,14 @@ export default class Scheduler {
     }
   }
 
-  async execute (datasourceConfig: DatasourceConfig): Promise<void> {
-    const datasourceId = datasourceConfig.id
-    for (let i = 0; i < this.triggerRetries; i++) {
-      try {
-        await AdapterClient.triggerDatasource(datasourceId)
-        console.log(`Datasource ${datasourceId} triggered.`)
-        break
-      } catch (error) {
-        if (isAxiosError(error)) {
-          handleAxiosError(error)
-        }
-        if (i === this.triggerRetries - 1) { // last retry
-          console.error(`Could not trigger datasource ${datasourceId}`)
-          break
-        }
-        console.info(`Triggering datasource failed - retrying (${i}/${this.triggerRetries})`)
-      }
-    }
-    this.reschedule(datasourceConfig)
-  }
-
-  async upsertJob (datasourceConfig: DatasourceConfig): Promise<SchedulingJob> {
+  upsertJob (datasourceConfig: DatasourceConfig): SchedulingJob {
     const isNewDatasource = !this.existsJob(datasourceConfig.id)
     const datasourceState = isNewDatasource ? 'New' : 'Updated'
 
     console.log(`[${datasourceState}] datasource detected with id ${datasourceConfig.id}.`)
 
-    if (!isNewDatasource) {
-      this.cancelJob(datasourceConfig.id)
-    }
-
     return this.scheduleDatasource(datasourceConfig)
   }
-
-  getAllJobs (): SchedulingJob[] {
-    return Array.from(this.allJobs.values())
-  }
-
-  cancelAllJobs (): void {
-    this.allJobs.forEach(job => {
-      schedule.cancelJob(job.scheduleJob)
-    })
-    this.allJobs.clear()
-  }
-
-  cancelJob (jobId: number): void {
-    const job = this.allJobs.get(jobId)
-    job?.scheduleJob.cancel()
-  }
-}
-
-const isAxiosError = function (error: any): error is AxiosError {
-  return error.isAxiosError
-}
-
-const handleAxiosError = function (error: AxiosError): void {
-  const baseMsg = 'Error during datasource triggering:'
-
-  if (error.response !== undefined) {
-    console.error(`${baseMsg} ${error.response.status}: ${error.response.data}`)
-    return
-  }
-
-  if (error.request !== undefined) {
-    console.error(`${baseMsg} ${JSON.stringify(error.request)}`)
-    return
-  }
-
-  console.error(`${baseMsg} unknown reason.`)
 }
 
 interface SchedulingJob {

--- a/scheduler/src/trigger-handler.ts
+++ b/scheduler/src/trigger-handler.ts
@@ -1,0 +1,37 @@
+import { AxiosError } from 'axios'
+
+import * as AdapterClient from './api/http/adapter-client'
+
+export async function triggerDatasource (datasourceId: number, triggerRetries: number): Promise<void> {
+  for (let i = 0; i < triggerRetries; i++) {
+    try {
+      await AdapterClient.triggerDatasource(datasourceId)
+      console.log(`Datasource ${datasourceId} triggered.`)
+      break
+    } catch (error) {
+      if (isAxiosError(error)) {
+        handleAxiosError(error)
+      }
+      if (i === triggerRetries - 1) { // last retry
+        console.error(`Could not trigger datasource ${datasourceId}`)
+        break
+      }
+      console.info(`Triggering datasource failed - retrying (${i}/${triggerRetries})`)
+    }
+  }
+}
+
+function isAxiosError (error: any): error is AxiosError {
+  return error.isAxiosError
+}
+
+function handleAxiosError (error: AxiosError): void {
+  const baseMsg = 'Error during datasource triggering:'
+
+  if (error.response !== undefined) {
+    console.error(`${baseMsg} ${error.response.status}: ${error.response.data}`)
+    return
+  }
+
+  console.error(`${baseMsg}:`, error.message)
+}


### PR DESCRIPTION
While investigation #284 I saw that all the main logic of the scheduler is in the `scheduling.ts` file. This made reasoning about it much more difficult. Therefore I have refactored the scheduler:
- extracted the initialization logic to a new `initializer.ts` file
- extracted the triggering logic to a new `trigger-handler.ts` file
- moved the unpacking of the datasource change event to the event consumer
- add some more test cases