### PR TITLE
Fix Adapter is missing RabbitMQ dependency in docker-compose.yml

### DIFF
--- a/docker-compose.it.yml
+++ b/docker-compose.it.yml
@@ -23,7 +23,6 @@ services:
     depends_on:
       - adapter
       - rabbitmq
-      - edge
 
   # ----------------- SCHEDULER SERVICE (PORTS 9300 - 9399) --------------------
   scheduler:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       context: ./adapter/
     depends_on:
       - adapter-db
+      - rabbitmq
     environment:
       DB_URL: jdbc:postgresql://adapter-db:5432/adapterservice
       RABBIT_HOST: rabbitmq


### PR DESCRIPTION
- Fix Adapter is missing RabbitMQ dependency in docker-compose.yml
- Remove edge as a dependency from adapter-it because it is not needed