### PR TITLE
Fix scheduler initialization

### DIFF
--- a/scheduler/src/index.ts
+++ b/scheduler/src/index.ts
@@ -2,7 +2,7 @@ import type { Server } from 'http'
 import express from 'express'
 
 import Scheduler from './scheduling'
-import { initSchedulerWithRetry } from './initializer'
+import { setupInitialStateWithRetry } from './initializer'
 
 import {
   CONNECTION_RETRIES,
@@ -28,7 +28,7 @@ async function main (): Promise<void> {
   const datasourceConfigConsumer = new DatasourceConfigConsumer(scheduler)
   await datasourceConfigConsumer.initialize(CONNECTION_RETRIES, CONNECTION_BACKOFF_IN_MS)
 
-  await initSchedulerWithRetry(scheduler, CONNECTION_RETRIES, CONNECTION_BACKOFF_IN_MS)
+  await setupInitialStateWithRetry(scheduler, CONNECTION_RETRIES, CONNECTION_BACKOFF_IN_MS)
 
   await datasourceConfigConsumer.startEventConsumption()
 

--- a/scheduler/src/index.ts
+++ b/scheduler/src/index.ts
@@ -30,6 +30,8 @@ async function main (): Promise<void> {
 
   await initSchedulerWithRetry(scheduler, CONNECTION_RETRIES, CONNECTION_BACKOFF_IN_MS)
 
+  await datasourceConfigConsumer.startEventConsumption()
+
   const app = express()
   app.get('/', (req, res) => {
     res.send('I am alive!')

--- a/scheduler/src/initializer.test.ts
+++ b/scheduler/src/initializer.test.ts
@@ -3,7 +3,7 @@ import { mocked } from 'ts-jest/utils'
 
 import { getAllDatasources } from './api/http/adapter-client'
 import Scheduler from './scheduling'
-import { initSchedulerWithRetry } from './initializer'
+import { setupInitialStateWithRetry } from './initializer'
 
 jest.mock('./api/http/adapter-client')
 const mockedGetAllDatasources = mocked(getAllDatasources)
@@ -36,7 +36,7 @@ describe('Scheduler initializer', () => {
     }
     mockedGetAllDatasources.mockResolvedValue([config])
 
-    await initSchedulerWithRetry(scheduler, CONNECTION_RETRIES, CONNECTION_BACKOFF_IN_MS)
+    await setupInitialStateWithRetry(scheduler, CONNECTION_RETRIES, CONNECTION_BACKOFF_IN_MS)
     expect(scheduler.getAllJobs()).toHaveLength(1)
     expect(scheduler.getAllJobs()[0].datasourceConfig).toEqual(config)
   })

--- a/scheduler/src/initializer.ts
+++ b/scheduler/src/initializer.ts
@@ -4,10 +4,14 @@ import DatasourceConfig from './api/datasource-config'
 import { getAllDatasources } from './api/http/adapter-client'
 import Scheduler from './scheduling'
 
-export async function initSchedulerWithRetry (scheduler: Scheduler, retries: number, backoff: number): Promise<void> {
+export async function setupInitialStateWithRetry (
+  scheduler: Scheduler,
+  retries: number,
+  backoff: number
+): Promise<void> {
   for (let i = 1; i <= retries; i++) {
     try {
-      await initScheduler(scheduler)
+      await setupInitialState(scheduler)
       return
     } catch (e) {
       if (e.code === 'ECONNREFUSED' || e.code === 'ENOTFOUND') {
@@ -22,7 +26,7 @@ export async function initSchedulerWithRetry (scheduler: Scheduler, retries: num
   throw new Error('Failed to initialize datasource/pipeline scheduler.')
 }
 
-async function initScheduler (scheduler: Scheduler): Promise<void> {
+async function setupInitialState (scheduler: Scheduler): Promise<void> {
   console.log('Starting scheduler initialization')
   const datasources: DatasourceConfig[] = await getAllDatasources()
   console.log(`Received ${datasources.length} datasources from adapter-service`)


### PR DESCRIPTION
Fixes #284

This copies some snippets of `node-dry-amqp` back to the scheduler because the underlying AMQP channel is not exposed by the `AmqpConsumer` and `AmqpPublisher`. I have deliberately not yet update the `node-dry-amqp` lib because there are some more issues around fault tolerance in the lib and with RabbitMQ in general, which require a complete refactor/rewrite of the  `node-dry-amqp` lib.