### PR TITLE
Fixed ODS not saving pipelines that output JSON arrays (#324)

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -10,8 +10,8 @@ The current implementation consists of the following parts:
 
 ## Getting Started
 
-* Build all containers with `docker-compose -f ../docker-compose.yml -f ../docker-compose.it.yml --env-file ../.env build storage-db-liquibase storage`
-* Run all containers with `docker-compose -f ../docker-compose.yml -f ../docker-compose.it.yml --env-file ../.env up storage-db storage-db-liquibase storage-db-ui storage storage-swagger` (includes Adminer on port 8081 as UI for db, Swagger-UI as UI on port 8080 for REST API, Integration Tests)
+* Build all containers with `docker-compose -f ../docker-compose.yml -f ../docker-compose.it.yml --env-file ../.env build storage-db-liquibase storage storage-mq`
+* Run all containers with `docker-compose -f ../docker-compose.yml -f ../docker-compose.it.yml --env-file ../.env up storage-db storage-db-liquibase storage-db-ui storage storage-swagger storage-mq` (includes Adminer on port 8081 as UI for db, Swagger-UI as UI on port 8080 for REST API, Integration Tests)
 Note that you need to delete existing docker images from your local docker daemon to have recent changes integrated: `docker system prune -f && docker volume prune -f`
 * For integration testing run `docker-compose -f ../docker-compose.yml -f ../docker-compose.it.yml --env-file ../.env up storage-it`.
 * To analyze the logs of the service under test we recommend using lazydocker. Alternatively, you can attach manually to the storage or storage-mq containers using the docker cli. 

--- a/storage/integration-test/src/storage-mq.test.js
+++ b/storage/integration-test/src/storage-mq.test.js
@@ -75,9 +75,10 @@ describe('IT against Storage-MQ service', () => {
     expect(response.body).toEqual([])
   }, TIMEOUT)
 
-  test('Should create bucket with content', async () => {
-    const pipelineId = 444
-
+  test.each([
+    [441, { exampleNumber: 123, exampleString: 'abc', exampleArray: [{ x: 'y' }, { t: 456 }] }],
+    [442, [1, 2, 3]]
+  ])('Should create bucket with content', async (pipelineId, data) => {
     const channel = await amqpConnection.createChannel()
     channel.assertExchange(AMQP_EXCHANGE, 'topic')
 
@@ -92,46 +93,7 @@ describe('IT against Storage-MQ service', () => {
     const pipelineExecutedEvent = {
       pipelineId: pipelineId,
       timestamp: new Date(Date.now()),
-      data: { exampleNumber: 123, exampleString: 'abc', exampleArray: [{ x: 'y' }, { t: 456 }] }
-    }
-    const execEventAsBuffer = Buffer.from(JSON.stringify(pipelineExecutedEvent))
-
-    channel.publish(AMQP_EXCHANGE, AMQP_PIPELINE_EXECUTION_SUCCESS_TOPIC, execEventAsBuffer)
-    await sleep(PROCESS_TIME)
-
-    const contentResponse = await request(STORAGEMQ_URL).get(`/bucket/${pipelineId}/content/1`)
-    expect(contentResponse.status).toEqual(200)
-    expect(contentResponse.type).toEqual('application/json')
-    expect(contentResponse.body.id).toEqual(1)
-    expect(contentResponse.body.timestamp).toEqual(pipelineExecutedEvent.timestamp.toISOString())
-    expect(contentResponse.body.pipelineId).toEqual(pipelineExecutedEvent.pipelineId)
-    expect(contentResponse.body.data).toEqual(pipelineExecutedEvent.data)
-
-    const allContentResponse = await request(STORAGEMQ_URL).get(`/bucket/${pipelineId}/content`)
-    expect(allContentResponse.status).toEqual(200)
-    expect(allContentResponse.type).toEqual('application/json')
-    expect(allContentResponse.body).toHaveLength(1)
-    expect(allContentResponse.body[0]).toEqual(contentResponse.body)
-  }, TIMEOUT)
-
-  test('Should create bucket with array content', async () => {
-    const pipelineId = 4442
-
-    const channel = await amqpConnection.createChannel()
-    channel.assertExchange(AMQP_EXCHANGE, 'topic')
-
-    const pipelineCreatedEvent = {
-      pipelineId: pipelineId
-    }
-    const eventAsBuffer = Buffer.from(JSON.stringify(pipelineCreatedEvent))
-
-    channel.publish(AMQP_EXCHANGE, AMQP_PIPELINE_CONFIG_CREATED_TOPIC, eventAsBuffer)
-    await sleep(PROCESS_TIME)
-
-    const pipelineExecutedEvent = {
-      pipelineId: pipelineId,
-      timestamp: new Date(Date.now()),
-      data: [1, 2, 3]
+      data: data
     }
     const execEventAsBuffer = Buffer.from(JSON.stringify(pipelineExecutedEvent))
 


### PR DESCRIPTION
fixes #324 

This PR:

- updates the storage documentation to include storage-mq in the list of containers to run (otherwise integration tests as described in the readme fail)
- adds an integration test that saves an array value and fails because the API response is 404
- fixes the failing test in the postgresStorageContentRepository with a reference to the open issue in the pg project