### PR TITLE
Fix pipeline stacktrace syntax error on CI.

### DIFF
--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "npm run transpile && npm run start:transpiled",
-    "start:transpiled": "node --enable-source-maps dist/index.js",
+    "start:transpiled": "node dist/index.js",
     "transpile": "tsc",
     "lint": "eslint src --fix",
     "lint-ci": "eslint src --max-warnings=0",

--- a/pipeline/src/pipeline-execution/sandbox/vm2StacktraceParser.ts
+++ b/pipeline/src/pipeline-execution/sandbox/vm2StacktraceParser.ts
@@ -10,7 +10,7 @@ import JobError from './jobError'
 export function parseStacktraceLine (line: string): [string, string, number, number] {
   const match = line.match(/^ +at (.+) \((.+):(\d+):(\d+)\)/)
   if (match === null) {
-    throw new Error('Unexpected stacktrace line format')
+    throw new Error(`Unexpected stacktrace line format: ${line}`)
   }
   const [, functionName, fileName, lineNumber, position] = match
   return [functionName, fileName, parseInt(lineNumber), parseInt(position)]
@@ -24,7 +24,7 @@ export function parseStacktraceLine (line: string): [string, string, number, num
 function parseSyntaxErrorHeader (header: string): [string, number] {
   const match = header.match(/^(.+):(\d+)/)
   if (match === null) {
-    throw new Error('Unexpected stacktrace format')
+    throw new Error(`Unexpected stacktrace format: ${header}`)
   }
   const [, fileName, lineNumber] = match
   return [fileName, parseInt(lineNumber)]


### PR DESCRIPTION
This PR was created to solve the failing CI test here: https://github.com/jvalue/open-data-service/runs/2646300675?check_suite_focus=true

and also here: https://github.com/jvalue/open-data-service/runs/2662359092

I was not able to reproduce the error locally, so I opened this PR in order to run my changes on the CI.