### PR TITLE
hotfix: set rabbitmq version to 3.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,7 +315,7 @@ services:
 
 # -------------------- RABBIT-MQ -------------------------------------------
   rabbitmq:
-    image:  rabbitmq:3-management-alpine
+    image:  rabbitmq:3.8-management-alpine
     environment:
       RABBITMQ_ERLANG_COOKIE: 'S0m3_R4bBi7_C0ok13'
       RABBITMQ_DEFAULT_USER: 'rabbit_adm'


### PR DESCRIPTION
hotfixes #347 .

We need a better solution though of course.