### PR TITLE
FIX: Pinned rabbitmq version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,7 +315,7 @@ services:
 
 # -------------------- RABBIT-MQ -------------------------------------------
   rabbitmq:
-    image:  rabbitmq:3-management-alpine
+    image:  rabbitmq:3.8-management-alpine
     environment:
       RABBITMQ_ERLANG_COOKIE: 'S0m3_R4bBi7_C0ok13'
       RABBITMQ_DEFAULT_USER: 'rabbit_adm'


### PR DESCRIPTION
Downgraded `rabbitmq` - as version 3.9 won't start with the current config. 

```bash
$ docker-compose up rabbitmq                                                                                                   130 main!?
Starting open-data-service_rabbitmq_1 ... done
Attaching to open-data-service_rabbitmq_1
rabbitmq_1              | error: RABBITMQ_DEFAULT_PASS is set but deprecated
rabbitmq_1              | error: RABBITMQ_DEFAULT_USER is set but deprecated
rabbitmq_1              | error: RABBITMQ_ERLANG_COOKIE is set but deprecated
rabbitmq_1              | error: deprecated environment variables detected
rabbitmq_1              | 
rabbitmq_1              | Please use a configuration file instead; visit https://www.rabbitmq.com/configure.html to learn more
rabbitmq_1              | 
open-data-service_rabbitmq_1 exited with code 1
```

This is to be considered in a hotfix/workaround manner