### PR TITLE
Allow self signed certs

### DIFF
--- a/notification/src/notification-config/postgresNotificationRepository.ts
+++ b/notification/src/notification-config/postgresNotificationRepository.ts
@@ -37,7 +37,7 @@ const POOL_CONFIG: PoolConfig = {
   user: POSTGRES_USER,
   password: POSTGRES_PW,
   database: POSTGRES_DB,
-  ssl: POSTGRES_SSL ? true : { rejectUnauthorized: false },
+  ssl: POSTGRES_SSL ? { rejectUnauthorized: false } : false,
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000

--- a/notification/src/notification-config/postgresNotificationRepository.ts
+++ b/notification/src/notification-config/postgresNotificationRepository.ts
@@ -37,7 +37,7 @@ const POOL_CONFIG: PoolConfig = {
   user: POSTGRES_USER,
   password: POSTGRES_PW,
   database: POSTGRES_DB,
-  ssl: POSTGRES_SSL,
+  ssl: POSTGRES_SSL ? true : { rejectUnauthorized: false },
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000

--- a/pipeline/src/pipeline-config/pipelineDatabase.ts
+++ b/pipeline/src/pipeline-config/pipelineDatabase.ts
@@ -13,7 +13,7 @@ const POOL_CONFIG: PoolConfig = {
   user: POSTGRES_USER,
   password: POSTGRES_PW,
   database: POSTGRES_DB,
-  ssl: POSTGRES_SSL,
+  ssl: POSTGRES_SSL ? true : { rejectUnauthorized: false },
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000

--- a/pipeline/src/pipeline-config/pipelineDatabase.ts
+++ b/pipeline/src/pipeline-config/pipelineDatabase.ts
@@ -13,7 +13,7 @@ const POOL_CONFIG: PoolConfig = {
   user: POSTGRES_USER,
   password: POSTGRES_PW,
   database: POSTGRES_DB,
-  ssl: POSTGRES_SSL ? true : { rejectUnauthorized: false },
+  ssl: POSTGRES_SSL ? { rejectUnauthorized: false } : false,
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000


### PR DESCRIPTION
Changed to DB operator again. It uses a self-signed certificate, I disabled it for the previous microservices
