### PR TITLE
Improve Dockerfile of Adapter

### DIFF
--- a/adapter/Dockerfile
+++ b/adapter/Dockerfile
@@ -6,8 +6,16 @@ FROM gradle:6.7-jdk15-openj9 as builder
 
 WORKDIR /builder
 
-# Copy project files
+# Copy gradle files
 COPY *.gradle /builder/
+
+# Required when downloading the dependencies:
+COPY src/main/resources/application.properties /builder/src/main/resources/application.properties
+
+# Download dependencies
+RUN gradle dependencies --refresh-dependencies --info
+
+# Copy remaining source files
 COPY src /builder/src
 
 # Build project and run unit tests


### PR DESCRIPTION
This PR introduces a small change to the Dockerfile of Adapter. It improves the build times when the source code changes but the dependencies stay the same by downloading and caching the dependencies before copying the actual source files.