### PR TITLE
Fix faulty mocking in provider-side CDC-Test of Pipeline

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -37,8 +37,8 @@ Use `npm test` to run the unit tests. There is also `nrm run watch-test` availab
 | *base_url*/configs | GET | - | PipelineConfig[] | Get all pipeline configs |
 | *base_url*/configs/:id | GET | - | PipelineConfig | Get pipeline config by id |
 | *base_url*/configs | POST | PipelineConfigDTO | PipelineConfig | Create a pipeline config |
-| *base_url*/configs/:id | PUT | PipelineConfigDTO | text | Update a pipeline config |
-| *base_url*/configs/:id | DELETE | - | text | Delete a pipeline config by id |
+| *base_url*/configs/:id | PUT | PipelineConfigDTO | PipelineConfig | Update a pipeline config |
+| *base_url*/configs/:id | DELETE | - | PipelineConfig | Delete a pipeline config by id |
 | *base_url*/configs | DELETE | - | text | Delete all pipeline configs |
 
 ### PipelineExecutionRequest

--- a/pipeline/integration-test/src/pipeline-config.test.js
+++ b/pipeline/integration-test/src/pipeline-config.test.js
@@ -79,7 +79,14 @@ describe('Pipeline Config Test', () => {
       .delete('/configs/' + configId)
       .send()
 
-    expect(delResponse.status).toEqual(204)
+    expect(delResponse.status).toEqual(200)
+    expect(delResponse.body).toEqual(
+      expect.objectContaining({
+        ...pipelineConfig,
+        id: configId,
+        metadata: expect.objectContaining(pipelineConfig.metadata)
+      })
+    )
 
     await sleep(PUBLICATION_WAIT_TIME_MS)
     expect(getPublishedEvent(AMQP_PIPELINE_CONFIG_CREATED_TOPIC)).toContainEqual({
@@ -108,7 +115,14 @@ describe('Pipeline Config Test', () => {
       .put('/configs/' + configId)
       .send(updatedConfig)
 
-    expect(putResponse.status).toEqual(204)
+    expect(putResponse.status).toEqual(200)
+    expect(putResponse.body).toEqual(
+      expect.objectContaining({
+        ...updatedConfig,
+        id: configId,
+        metadata: expect.objectContaining(updatedConfig.metadata)
+      })
+    )
 
     const updatedGetResponse = await request(URL)
       .get('/configs/' + configId)
@@ -122,7 +136,14 @@ describe('Pipeline Config Test', () => {
       .delete('/configs/' + configId)
       .send()
 
-    expect(delResponse.status).toEqual(204)
+    expect(delResponse.status).toEqual(200)
+    expect(delResponse.body).toEqual(
+      expect.objectContaining({
+        ...updatedConfig,
+        id: configId,
+        metadata: expect.objectContaining(updatedConfig.metadata)
+      })
+    )
 
     await sleep(PUBLICATION_WAIT_TIME_MS)
     expect(getPublishedEvent(AMQP_PIPELINE_CONFIG_CREATED_TOPIC)).toContainEqual({

--- a/pipeline/src/api/rest/pipelineConfigEndpoint.ts
+++ b/pipeline/src/api/rest/pipelineConfigEndpoint.ts
@@ -31,7 +31,8 @@ export class PipelineConfigEndpoint {
     }
     const deletedPipeline = await this.pipelineConfigManager.delete(configId);
     if (deletedPipeline === undefined) {
-      res.status(204).send();
+      res.status(404).send(`Could not find config with id ${configId}`);
+      return;
     }
     res.status(200).json(deletedPipeline);
   };

--- a/pipeline/src/api/rest/pipelineConfigEndpoint.ts
+++ b/pipeline/src/api/rest/pipelineConfigEndpoint.ts
@@ -29,8 +29,11 @@ export class PipelineConfigEndpoint {
       res.status(400).send('Path parameter id is missing or is incorrect');
       return;
     }
-    await this.pipelineConfigManager.delete(configId);
-    res.status(204).send();
+    const deletedPipeline = await this.pipelineConfigManager.delete(configId);
+    if (deletedPipeline === undefined) {
+      res.status(204).send();
+    }
+    res.status(200).json(deletedPipeline);
   };
 
   deleteAll = async (
@@ -56,15 +59,16 @@ export class PipelineConfigEndpoint {
       return;
     }
     const config = req.body;
-    try {
-      await this.pipelineConfigManager.update(configId, config);
-    } catch (e) {
-      res
-        .status(404)
-        .send(`Could not find config with id ${configId}: ${String(e)}`);
+
+    const updatedPipeline = await this.pipelineConfigManager.update(
+      configId,
+      config,
+    );
+    if (updatedPipeline === undefined) {
+      res.status(404).send(`Could not find config with id ${configId}`);
       return;
     }
-    res.status(204).send();
+    res.status(200).json(updatedPipeline);
   };
 
   create = async (

--- a/pipeline/src/pipeline-config/pipelineConfigManager.test.ts
+++ b/pipeline/src/pipeline-config/pipelineConfigManager.test.ts
@@ -37,7 +37,7 @@ jest.mock('./pipelineConfigRepository', () => {
     get: jest.fn(),
     getAll: jest.fn().mockResolvedValue([generateConfig(), generateConfig()]),
     getByDatasourceId: jest.fn(),
-    update: jest.fn(),
+    update: jest.fn().mockResolvedValue(generateConfig()),
     deleteById: jest.fn().mockResolvedValue(generateConfig()),
     deleteAll: jest
       .fn()

--- a/pipeline/src/pipeline-config/pipelineConfigManager.ts
+++ b/pipeline/src/pipeline-config/pipelineConfigManager.ts
@@ -47,28 +47,41 @@ export class PipelineConfigManager {
     );
   }
 
-  async update(id: number, config: PipelineConfigDTO): Promise<void> {
+  async update(
+    id: number,
+    config: PipelineConfigDTO,
+  ): Promise<PipelineConfig | undefined> {
     return await this.pgClient.transaction(async (client) => {
-      await PipelineConfigRepository.update(client, id, config);
-      await EventPublisher.publishUpdate(
+      const updatedPipeline = await PipelineConfigRepository.update(
         client,
         id,
-        config.metadata.displayName,
+        config,
       );
+      if (updatedPipeline !== undefined) {
+        await EventPublisher.publishUpdate(
+          client,
+          id,
+          config.metadata.displayName,
+        );
+      }
+      return updatedPipeline;
     });
   }
 
-  async delete(id: number): Promise<void> {
+  async delete(id: number): Promise<PipelineConfig | undefined> {
     return await this.pgClient.transaction(async (client) => {
       const deletedPipeline = await PipelineConfigRepository.deleteById(
         client,
         id,
       );
-      await EventPublisher.publishDeletion(
-        client,
-        id,
-        deletedPipeline.metadata.displayName,
-      );
+      if (deletedPipeline !== undefined) {
+        await EventPublisher.publishDeletion(
+          client,
+          id,
+          deletedPipeline.metadata.displayName,
+        );
+      }
+      return deletedPipeline;
     });
   }
 

--- a/pipeline/src/pipeline-config/pipelineConfigRepository.ts
+++ b/pipeline/src/pipeline-config/pipelineConfigRepository.ts
@@ -27,7 +27,7 @@ const INSERT_CONFIG_STATEMENT = `
 const UPDATE_CONFIG_STATEMENT = `
   UPDATE "${POSTGRES_SCHEMA}"."${CONFIG_TABLE_NAME}"
   SET "datasourceId"=$2, "func"=$3, "author"=$4, "displayName"=$5, "license"=$6, "description"=$7, "schema"=$8
-  WHERE id=$1`;
+  WHERE id=$1 RETURNING *`;
 const GET_CONFIG_STATEMENT = `
   SELECT * FROM "${POSTGRES_SCHEMA}"."${CONFIG_TABLE_NAME}" WHERE "id" = $1`;
 const GET_ALL_CONFIGS_STATEMENT = `
@@ -107,7 +107,7 @@ export async function update(
   client: ClientBase,
   id: number,
   config: PipelineConfigDTO,
-): Promise<void> {
+): Promise<PipelineConfig | undefined> {
   const values = [
     id,
     config.datasourceId,
@@ -119,20 +119,18 @@ export async function update(
     config.schema,
   ];
   const result = await client.query(UPDATE_CONFIG_STATEMENT, values);
-  if (result.rowCount === 0) {
-    throw new Error(`Could not find config with ${id} to update`);
-  }
+  const content = toPipelineConfigs(result);
+  // Returns undefined if the array is empty
+  return content[0];
 }
 
 export async function deleteById(
   client: ClientBase,
   id: number,
-): Promise<PipelineConfig> {
+): Promise<PipelineConfig | undefined> {
   const result = await client.query(DELETE_CONFIG_STATEMENT, [id]);
-  if (result.rowCount === 0) {
-    throw new Error(`Could not find config with ${id} to delete`);
-  }
   const content = toPipelineConfigs(result);
+  // Returns undefined if the array is empty
   return content[0];
 }
 

--- a/pipeline/src/ui.provider.pact.test.ts
+++ b/pipeline/src/ui.provider.pact.test.ts
@@ -20,49 +20,72 @@ jest.mock('./pipeline-config/pipelineConfigManager', () => {
       return {
         getAll: jest.fn().mockResolvedValue(pipelineConfigs),
 
-        get: jest.fn().mockImplementation(async (id: number) => {
-          const result = pipelineConfigs.find((config) => config.id === id);
-          return Promise.resolve(result);
-        }),
+        get: jest
+          .fn()
+          .mockImplementation(
+            async (id: number): Promise<PipelineConfig | undefined> => {
+              const result = pipelineConfigs.find((config) => config.id === id);
+              return Promise.resolve(result);
+            },
+          ),
 
         getByDatasourceId: jest
           .fn()
-          .mockImplementation(async (datasourceId: number) => {
-            const result = pipelineConfigs.filter(
-              (config) => config.datasourceId === datasourceId,
-            );
-            return Promise.resolve(result);
-          }),
+          .mockImplementation(
+            async (datasourceId: number): Promise<PipelineConfig[]> => {
+              const result = pipelineConfigs.filter(
+                (config) => config.datasourceId === datasourceId,
+              );
+              return Promise.resolve(result);
+            },
+          ),
 
         create: jest
           .fn()
-          .mockImplementation(async (config: PipelineConfigDTO) => {
-            const result: PipelineConfig = {
-              ...config,
-              metadata: {
-                ...config.metadata,
-                creationTimestamp: new Date(2022, 1),
-              },
-              id: ++nextPipelineConfigId,
-            };
-            pipelineConfigs.push(result);
-            return await Promise.resolve(result);
-          }),
+          .mockImplementation(
+            async (config: PipelineConfigDTO): Promise<PipelineConfig> => {
+              const result: PipelineConfig = {
+                ...config,
+                metadata: {
+                  ...config.metadata,
+                  creationTimestamp: new Date(2022, 1),
+                },
+                id: ++nextPipelineConfigId,
+              };
+              pipelineConfigs.push(result);
+              return Promise.resolve(result);
+            },
+          ),
 
-        update: jest.fn((id: number, config: PipelineConfigDTO) => {
-          const configToUpdate = pipelineConfigs.find(
-            (config) => config.id === id,
-          );
-          Object.assign(configToUpdate, config);
-        }),
+        update: jest.fn(
+          (
+            id: number,
+            config: PipelineConfigDTO,
+          ): Promise<PipelineConfig | undefined> => {
+            const configToUpdate = pipelineConfigs.find(
+              (config) => config.id === id,
+            );
 
-        delete: jest.fn((id: number) => {
+            if (configToUpdate === undefined) {
+              return Promise.resolve(undefined);
+            }
+            Object.assign(configToUpdate, config);
+            return Promise.resolve(configToUpdate);
+          },
+        ),
+
+        delete: jest.fn((id: number): Promise<PipelineConfig | undefined> => {
           const indexOfConfigToDelete = pipelineConfigs.findIndex(
             (config) => config.id === id,
           );
-          if (indexOfConfigToDelete !== -1) {
-            pipelineConfigs.splice(indexOfConfigToDelete, 1);
+
+          if (indexOfConfigToDelete === -1) {
+            return Promise.resolve(undefined);
           }
+
+          const configToDelete = pipelineConfigs[indexOfConfigToDelete];
+          pipelineConfigs.splice(indexOfConfigToDelete, 1);
+          return Promise.resolve(configToDelete);
         }),
       };
     }),

--- a/system-test/src/scenario1.test.js
+++ b/system-test/src/scenario1.test.js
@@ -95,7 +95,9 @@ describe('Test 1: Create non-periodic pipeline without transformation', () => {
 
   test('Delete pipeline config', async () => {
     const response = await request(PIPELINE_URL).delete(`/configs/${pipelineId}`).send()
-    expect(response.status).toEqual(204)
+    expect(response.status).toEqual(200)
+    expect(response.type).toEqual('application/json')
+    expect(response.body.id).toEqual(pipelineId)
   }, TEST_TIMEOUT)
 
   test('Delete adapter config', async () => {

--- a/system-test/src/scenario2.test.js
+++ b/system-test/src/scenario2.test.js
@@ -108,7 +108,9 @@ describe('Test 2: Create periodic pipeline without transformation', () => {
 
   test('Delete pipeline config', async () => {
     const response = await request(PIPELINE_URL).delete(`/configs/${pipelineId}`).send()
-    expect(response.status).toEqual(204)
+    expect(response.status).toEqual(200)
+    expect(response.type).toEqual('application/json')
+    expect(response.body.id).toEqual(pipelineId)
   }, TEST_TIMEOUT)
 
   test('Delete adapter config', async () => {

--- a/system-test/src/scenario3.test.js
+++ b/system-test/src/scenario3.test.js
@@ -99,7 +99,9 @@ describe('Test 3: Create non-periodic pipeline with transformation', () => {
 
   test('Delete pipeline config', async () => {
     const response = await request(PIPELINE_URL).delete(`/configs/${pipelineId}`).send()
-    expect(response.status).toEqual(204)
+    expect(response.status).toEqual(200)
+    expect(response.type).toEqual('application/json')
+    expect(response.body.id).toEqual(pipelineId)
   }, TEST_TIMEOUT)
 
   test('Delete adapter config', async () => {

--- a/system-test/src/scenario4.test.js
+++ b/system-test/src/scenario4.test.js
@@ -112,7 +112,15 @@ describe('Test 4: Update periodic datasource with pipeline', () => {
     pipelineConfig.id = pipelineId
 
     const updateResponse = await request(PIPELINE_URL).put(`/configs/${pipelineId}`).send(pipelineConfig)
-    expect(updateResponse.status).toEqual(204)
+    expect(updateResponse.status).toEqual(200)
+    expect(updateResponse.type).toEqual('application/json')
+    expect(updateResponse.body).toEqual(
+      expect.objectContaining({
+        id: pipelineId,
+        datasourceId: pipelineConfig.datasourceId,
+        metadata: expect.objectContaining(pipelineConfig.metadata)
+      })
+    )
   })
 
   test('Add second notification', async () => {
@@ -138,7 +146,9 @@ describe('Test 4: Update periodic datasource with pipeline', () => {
 
   test('Delete pipeline config', async () => {
     const response = await request(PIPELINE_URL).delete(`/configs/${pipelineId}`).send()
-    expect(response.status).toEqual(204)
+    expect(response.status).toEqual(200)
+    expect(response.type).toEqual('application/json')
+    expect(response.body.id).toEqual(pipelineId)
   }, TEST_TIMEOUT)
 
   test('Delete adapter config', async () => {

--- a/system-test/src/scenario5.test.js
+++ b/system-test/src/scenario5.test.js
@@ -135,7 +135,9 @@ describe('Test 5: Create pipeline with multiple notifications', () => {
 
   test('Delete pipeline config', async () => {
     const response = await request(PIPELINE_URL).delete(`/configs/${pipelineId}`).send()
-    expect(response.status).toEqual(204)
+    expect(response.status).toEqual(200)
+    expect(response.type).toEqual('application/json')
+    expect(response.body.id).toEqual(pipelineId)
   }, TEST_TIMEOUT)
 
   test('Delete adapter config', async () => {

--- a/system-test/src/scenario6.test.js
+++ b/system-test/src/scenario6.test.js
@@ -86,7 +86,9 @@ describe('Test 6: Delete periodic pipeline', () => {
 
   test('Delete pipeline config', async () => {
     const response = await request(PIPELINE_URL).delete(`/configs/${pipelineId}`).send()
-    expect(response.status).toEqual(204)
+    expect(response.status).toEqual(200)
+    expect(response.type).toEqual('application/json')
+    expect(response.body.id).toEqual(pipelineId)
   }, TEST_TIMEOUT)
 
   test('Notification webhook does not return new data', async () => {

--- a/ui/src/pipeline.consumer.pact.fixtures.ts
+++ b/ui/src/pipeline.consumer.pact.fixtures.ts
@@ -340,10 +340,6 @@ export const transformDataErrorThrownResponse: ResponseOptions = {
   }),
 };
 
-export const noContentResponse: ResponseOptions = {
-  status: 204,
-};
-
 export const notFoundResponse: ResponseOptions = {
   // TODO any status code that results in throwing an error is actually acceptable (i.e. 4xx, 5xx)
   status: 404,

--- a/ui/src/pipeline.consumer.pact.fixtures.ts
+++ b/ui/src/pipeline.consumer.pact.fixtures.ts
@@ -163,10 +163,18 @@ export function updateRequest(pipeline: Pipeline): RequestOptions {
   };
 }
 
-export const updateSuccessResponse: ResponseOptions = {
-  // TODO any success status code is actually acceptable (i.e. 2xx)
-  status: 204,
-};
+export function updateSuccessResponse(withSchema: boolean): ResponseOptions {
+  return {
+    // TODO any success status code is actually acceptable (i.e. 2xx)
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: like(
+      withSchema ? examplePipelineWithSchema : examplePipelineWithoutSchema,
+    ),
+  };
+}
 
 export function deleteRequestTitle(id: number): string {
   return `a request for deleting the pipeline with id ${id}`;
@@ -179,10 +187,18 @@ export function deleteRequest(id: number): RequestOptions {
   };
 }
 
-export const deleteSuccessResponse: ResponseOptions = {
-  // TODO any success status code is actually acceptable (i.e. 2xx)
-  status: 204,
-};
+export function deleteSuccessResponse(withSchema: boolean): ResponseOptions {
+  return {
+    // TODO any success status code except 204 is actually acceptable (i.e. 2xx)
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: like(
+      withSchema ? examplePipelineWithSchema : examplePipelineWithoutSchema,
+    ),
+  };
+}
 
 export const exampleTransformedDataId = 1;
 
@@ -322,6 +338,10 @@ export const transformDataErrorThrownResponse: ResponseOptions = {
       stacktrace: eachLike(exampleErrorThrownJobResult.error?.stacktrace[0]),
     },
   }),
+};
+
+export const noContentResponse: ResponseOptions = {
+  status: 204,
 };
 
 export const notFoundResponse: ResponseOptions = {

--- a/ui/src/pipeline.consumer.pact.test.ts
+++ b/ui/src/pipeline.consumer.pact.test.ts
@@ -35,7 +35,6 @@ import {
   getLatestTransformedDataRequest,
   getLatestTransformedDataRequestTitle,
   getLatestTransformedDataSuccessResponse,
-  noContentResponse,
   notFoundResponse,
   transformDataErrorThrownResponse,
   transformDataInvalidSyntaxResponse,
@@ -442,12 +441,12 @@ pactWith(options, provider => {
             state: `pipeline with id ${id} does not exist`,
             uponReceiving: deleteRequestTitle(id),
             withRequest: deleteRequest(id),
-            willRespondWith: noContentResponse,
+            willRespondWith: notFoundResponse,
           });
         });
 
-        it('returns undefined', async () => {
-          expect(await restService.deletePipeline(id)).toBeUndefined();
+        it('throws an error', async () => {
+          await expect(restService.deletePipeline(id)).rejects.toThrow(Error);
         });
       });
 

--- a/ui/src/pipeline.consumer.pact.test.ts
+++ b/ui/src/pipeline.consumer.pact.test.ts
@@ -35,6 +35,7 @@ import {
   getLatestTransformedDataRequest,
   getLatestTransformedDataRequestTitle,
   getLatestTransformedDataSuccessResponse,
+  noContentResponse,
   notFoundResponse,
   transformDataErrorThrownResponse,
   transformDataInvalidSyntaxResponse,
@@ -324,7 +325,7 @@ pactWith(options, provider => {
             state: `pipeline with id ${pipeline.id} exists`,
             uponReceiving: updateRequestTitle(pipeline.id, false),
             withRequest: updateRequest(pipeline),
-            willRespondWith: updateSuccessResponse,
+            willRespondWith: updateSuccessResponse(false),
           });
         });
 
@@ -341,12 +342,14 @@ pactWith(options, provider => {
             state: `pipeline with id ${pipeline.id} exists`,
             uponReceiving: updateRequestTitle(pipeline.id, true),
             withRequest: updateRequest(pipeline),
-            willRespondWith: updateSuccessResponse,
+            willRespondWith: updateSuccessResponse(true),
           });
         });
 
-        it('succeeds', async () => {
-          await restService.updatePipeline(pipeline);
+        it('returns the updated pipeline', async () => {
+          const updatedPipeline = await restService.updatePipeline(pipeline);
+
+          expect(updatedPipeline).toStrictEqual(pipeline);
         });
       });
 
@@ -393,20 +396,41 @@ pactWith(options, provider => {
     });
 
     describe('deleting a pipeline', () => {
-      describe('when the pipeline to delete exists', () => {
-        const id = examplePipelineId;
+      describe('when the pipeline to delete exists and has no schema', () => {
+        const pipeline = examplePipelineWithoutSchema;
 
         beforeEach(async () => {
           await provider.addInteraction({
-            state: `pipeline with id ${id} exists`,
-            uponReceiving: deleteRequestTitle(id),
-            withRequest: deleteRequest(id),
-            willRespondWith: deleteSuccessResponse,
+            state: `pipeline with id ${pipeline.id} exists and has no schema`,
+            uponReceiving: deleteRequestTitle(pipeline.id),
+            withRequest: deleteRequest(pipeline.id),
+            willRespondWith: deleteSuccessResponse(false),
           });
         });
 
-        it('succeeds', async () => {
-          await restService.deletePipeline(id);
+        it('returns the deleted pipeline', async () => {
+          const deletedPipeline = await restService.deletePipeline(pipeline.id);
+
+          expect(deletedPipeline).toStrictEqual(pipeline);
+        });
+      });
+
+      describe('when the pipeline to delete exists and has a schema', () => {
+        const pipeline = examplePipelineWithSchema;
+
+        beforeEach(async () => {
+          await provider.addInteraction({
+            state: `pipeline with id ${pipeline.id} exists and has a schema`,
+            uponReceiving: deleteRequestTitle(pipeline.id),
+            withRequest: deleteRequest(pipeline.id),
+            willRespondWith: deleteSuccessResponse(true),
+          });
+        });
+
+        it('returns the deleted pipeline', async () => {
+          const deletedPipeline = await restService.deletePipeline(pipeline.id);
+
+          expect(deletedPipeline).toStrictEqual(pipeline);
         });
       });
 
@@ -418,16 +442,16 @@ pactWith(options, provider => {
             state: `pipeline with id ${id} does not exist`,
             uponReceiving: deleteRequestTitle(id),
             withRequest: deleteRequest(id),
-            willRespondWith: deleteSuccessResponse,
+            willRespondWith: noContentResponse,
           });
         });
 
-        it('succeeds', async () => {
-          await restService.deletePipeline(id);
+        it('returns undefined', async () => {
+          expect(await restService.deletePipeline(id)).toBeUndefined();
         });
       });
 
-      describe('with NaN as id for the pipline to update', () => {
+      describe('with NaN as id for the pipline to delete', () => {
         beforeEach(async () => {
           await provider.addInteraction({
             state: 'any state',

--- a/ui/src/pipeline/pipelineRest.ts
+++ b/ui/src/pipeline/pipelineRest.ts
@@ -51,13 +51,8 @@ export class PipelineRest {
     return JSON.parse(response.data) as Pipeline;
   }
 
-  async deletePipeline(id: number): Promise<Pipeline | undefined> {
+  async deletePipeline(id: number): Promise<Pipeline> {
     const response = await this.httpPipelineConfigs.delete(`/${id}`);
-
-    if (response.status === 204) {
-      return undefined;
-    }
-
     return JSON.parse(response.data) as Pipeline;
   }
 }

--- a/ui/src/pipeline/pipelineRest.ts
+++ b/ui/src/pipeline/pipelineRest.ts
@@ -43,14 +43,21 @@ export class PipelineRest {
     return JSON.parse(response.data) as Pipeline;
   }
 
-  async updatePipeline(pipeline: Pipeline): Promise<void> {
-    await this.httpPipelineConfigs.put(
+  async updatePipeline(pipeline: Pipeline): Promise<Pipeline> {
+    const response = await this.httpPipelineConfigs.put(
       `/${pipeline.id}`,
       JSON.stringify(pipeline),
     );
+    return JSON.parse(response.data) as Pipeline;
   }
 
-  async deletePipeline(id: number): Promise<void> {
-    await this.httpPipelineConfigs.delete(`/${id}`);
+  async deletePipeline(id: number): Promise<Pipeline | undefined> {
+    const response = await this.httpPipelineConfigs.delete(`/${id}`);
+
+    if (response.status === 204) {
+      return undefined;
+    }
+
+    return JSON.parse(response.data) as Pipeline;
   }
 }


### PR DESCRIPTION
This PR fixes faulty mocking that was present in the provider-side CDC-Test. The mocked behaviour of `PipelineConfigManager` for updating and deleting pipelines did not match its actual behavior in cases where there is no pipeline with the requested id.

In order to fix that problem, I modified the interactions between UI and Pipeline to ease the implementation of the mock. In particular for updating/deleting, the `PipelineConfigManager` now returns `undefined` if a pipeline with the given id does not exist and returns the updated/deleted pipeline if it exists.
Due to these interaction changes, a unit test and some integration and system tests had to be adjusted.