### PR TITLE
Feature/329 datasource execution after creation

### DIFF
--- a/ui/src/datasource/datasourceRest.ts
+++ b/ui/src/datasource/datasourceRest.ts
@@ -81,3 +81,10 @@ export async function getLatestDataimport(
   const jsonResponse = JSON.parse(importResponse.data) as DataimportMetaData;
   return jsonResponse;
 }
+
+export async function triggerDatasource(
+  id: number,
+): Promise<DataimportMetaData> {
+  const triggerResponse = await http.post(`/datasources/${id}/trigger`);
+  return JSON.parse(triggerResponse.data) as DataimportMetaData;
+}


### PR DESCRIPTION
- Added manual datasource trigger action (including disable of button to prevent spamming / for simple visual feedback)
- Fixed uncaught error in for loop during status retrival

**Changes**
Before:
![image](https://user-images.githubusercontent.com/52160939/147224730-109ce5fe-4a3a-428d-a2d7-96acae289599.png)

After:
![image](https://user-images.githubusercontent.com/52160939/147225559-ee48ac2c-a4f6-4506-9425-d1668b26c324.png)
(With tooltip for new action reading: "Trigger datasource")