### PR TITLE
Added mounted lifecycle hook to extract intervals

### DIFF
--- a/ui/src/datasource/edit/TriggerConfig.vue
+++ b/ui/src/datasource/edit/TriggerConfig.vue
@@ -142,6 +142,12 @@ export default class TriggerConfig extends Vue {
   @PropSync('value')
   private triggerConfig!: Trigger;
 
+  private mounted(): void {
+    if (this.triggerConfig !== undefined) {
+      this.loadDialogIntervalForSlider();
+    }
+  }
+
   private minutesTickLabels(): string[] {
     const ticks = new Array<string>(61);
     ticks[0] = '0m';


### PR DESCRIPTION
Found the issue:
The watcher is not triggering due to the fact, that `@PropSync('value') private triggerConfig!: Trigger;` already contains the synced value, and not undefined
-> simply added mounted lifecycle hook which executes the same (keeping watcher just in case)